### PR TITLE
Optimize Saved Searches

### DIFF
--- a/cyences_app_for_splunk/default/savedsearches.conf
+++ b/cyences_app_for_splunk/default/savedsearches.conf
@@ -1051,7 +1051,7 @@ display.page.search.tab = statistics
 display.page.search.mode = fast
 request.ui_dispatch_app = cyences_app_for_splunk
 request.ui_dispatch_view = search
-search = `cs_all_indexes` _index_earliest=-60m@m _index_latest=now | stats max(_indextime) as last_event, dc(sourcetype) as no_sourcetypes, dc(host) as no_hosts by index \
+search = | tstats max(_indextime) as last_event, dc(sourcetype) as no_sourcetypes, dc(host) as no_hosts where `cs_all_indexes`  _index_earliest=-60m@m _index_latest=now by index \
 | inputlookup append=true cs_indexes.csv \
 | stats max(last_event) as last_event, last(no_sourcetypes) as no_sourcetypes, last(no_hosts) as no_hosts, last(sourcetypes) as sourcetypes, last(hosts) as hosts by index \
 | eval status = if(last_event < (now() - 3600), "Missing", "Active") | eval status=if(status="Active" AND no_sourcetypes<sourcetypes, "Missing Sourcetypes", status) | eval status=if(status="Active" AND no_hosts<hosts, "Missing Hosts", status) \


### PR DESCRIPTION
Instead of search event details from the whole index, search from tsidx files only.