### PR TITLE
CY-317: Add o365 login related alerts

### DIFF
--- a/cyences_app_for_splunk/default/macros.conf
+++ b/cyences_app_for_splunk/default/macros.conf
@@ -614,7 +614,7 @@ iseval = 0
 definition = search *
 iseval = 0
 
-[confirmiplocation]
+[cs_confirmiplocation]
 definition = search *
 iseval = 0
 

--- a/cyences_app_for_splunk/default/macros.conf
+++ b/cyences_app_for_splunk/default/macros.conf
@@ -610,7 +610,27 @@ iseval = 0
 definition = search *
 iseval = 0
 
+[cs_o365_failed_login_due_to_mfs_filter]
+definition = search *
+iseval = 0
+
+[confirmiplocation]
+definition = search *
+iseval = 0
+
+[cs_o365_failed_login_due_to_mfs_outside_country_filter]
+definition = search *
+iseval = 0
+
+[cs_o365_failed_login_due_to_conditional_access_policy_filter]
+definition = search *
+iseval = 0
+
 [cs_o365_login_by_unknown_userid_filter]
+definition = search *
+iseval = 0
+
+[cs_o365_daily_login_failure_filter]
 definition = search *
 iseval = 0
 

--- a/cyences_app_for_splunk/default/savedsearches.conf
+++ b/cyences_app_for_splunk/default/savedsearches.conf
@@ -1487,6 +1487,215 @@ action.summary_index._name = cyences
 action.summary_index.category = O365
 action.summary_index.alert_name = O365 - Application Change/Update
 
+[O365 - Login failure due to multi factor authentication]
+disabled = 1
+enableSched = 1
+alert.track = 1
+alert.severity = 4
+alert.suppress = 0
+counttype = number of events
+quantity = 0
+relation = greater than
+cron_schedule =	29 * * * *
+description = This alert will show the login failure due to multi factor authentication. \
+\
+Data Collection - Office 365 management activity data (Splunk Add-on for Office 365). 
+dispatch.earliest_time = -85m@s
+dispatch.latest_time = -25m@s
+display.general.type = statistics
+display.page.search.tab = statistics
+display.page.search.mode = fast
+request.ui_dispatch_app = cyences_app_for_splunk
+request.ui_dispatch_view = search
+search = `cs_o365` sourcetype="o365:management:activity" Workload=AzureActiveDirectory Operation=UserLoginFailed (LogonError="DeviceAuthenticationRequired" OR LogonError="UserStrongAuthClientAuthNRequiredInterrupt") \
+| eval ExtendedProperties=mvzip('ExtendedProperties{}.Name','ExtendedProperties{}.Value'," : ") \
+| stats count, max(_time) as Last_Failed_Login, values(LogonError) as LogonError, values(ExtendedProperties) as ExtendedProperties by user, ClientIP \
+| iplocation ClientIP \
+| fillnull Country, Region, City value="-" \
+| eval Location=ClientIP." (".count.") | ".Country." | ".Region." | ".City \
+| stats sum(count) as count, max(Last_Failed_Login) as Last_Failed_Login, list(Location) as Location, values(LogonError) as LogonError, values(ExtendedProperties) as ExtendedProperties by user \
+| sort - count \
+| `cs_human_readable_time_format(Last_Failed_Login)` \
+| `cs_o365_failed_login_due_to_mfs_filter`
+action.summary_index = 1
+action.summary_index._name = cyences
+action.summary_index.category = O365
+action.summary_index.alert_name = O365 - Login failure due to multi factor authentication
+
+[O365 - Login failure outside US due to multi factor authentication]
+disabled = 1
+enableSched = 1
+alert.track = 1
+alert.severity = 4
+alert.suppress = 0
+counttype = number of events
+quantity = 0
+relation = greater than
+cron_schedule =	*/31 * * * *
+description = This alert will show the login failure outside US due to multi factor authentication. \
+\
+Data Collection - Office 365 management activity data (Splunk Add-on for Office 365). 
+dispatch.earliest_time = -55m@s
+dispatch.latest_time = -25m@s
+display.general.type = statistics
+display.page.search.tab = statistics
+display.page.search.mode = fast
+request.ui_dispatch_app = cyences_app_for_splunk
+request.ui_dispatch_view = search
+search = `cs_o365` sourcetype="o365:management:activity" Workload=AzureActiveDirectory Operation=UserLoginFailed (LogonError="DeviceAuthenticationRequired" OR LogonError="UserStrongAuthClientAuthNRequiredInterrupt") \
+| eval ExtendedProperties=mvzip('ExtendedProperties{}.Name','ExtendedProperties{}.Value'," : ") \
+| stats count, max(_time) as Last_Failed_Login, values(LogonError) as LogonError, values(ExtendedProperties) as ExtendedProperties by user, ClientIP \
+| iplocation ClientIP \
+| where Country!=`cs_home_country` \
+| `confirmiplocation` \
+| fillnull Country, Region, City value="-" \
+| eval Location=ClientIP." (".count.") | ".Country." | ".Region." | ".City \
+| stats sum(count) as count, max(Last_Failed_Login) as Last_Failed_Login, list(Location) as Location, values(LogonError) as LogonError, values(ExtendedProperties) as ExtendedProperties by user \
+| sort - count \
+| `cs_human_readable_time_format(Last_Failed_Login)` \
+| `cs_o365_failed_login_due_to_mfs_outside_country_filter`
+action.summary_index = 1
+action.summary_index._name = cyences
+action.summary_index.category = O365
+action.summary_index.alert_name = O365 - Login failure outside US due to multi factor authentication
+
+[O365 - Login from unknown user]
+disabled = 1
+enableSched = 1
+alert.track = 1
+alert.severity = 4
+alert.suppress = 0
+counttype = number of events
+quantity = 0
+relation = greater than
+cron_schedule =	*/31 * * * *
+description = This alert will show the Login from unknown user. \
+\
+Data Collection - Office 365 management activity data (Splunk Add-on for Office 365). 
+dispatch.earliest_time = -55m@s
+dispatch.latest_time = -25m@s
+display.general.type = statistics
+display.page.search.tab = statistics
+display.page.search.mode = fast
+request.ui_dispatch_app = cyences_app_for_splunk
+request.ui_dispatch_view = search
+search = `cs_o365` sourcetype="o365:management:activity" Workload=AzureActiveDirectory Operation=UserLoggedIn UserId=Unknown \
+| stats count, max(_time) as Last_Success_Login by ClientIP \
+| iplocation ClientIP \
+| sort - count \
+| `cs_human_readable_time_format(Last_Success_Login)` \
+| `cs_o365_login_by_unknown_userid_filter`
+action.summary_index = 1
+action.summary_index._name = cyences
+action.summary_index.category = O365
+action.summary_index.alert_name = O365 - Login from unknown user
+
+[O365 - Successful login outside US]
+disabled = 1
+enableSched = 1
+alert.track = 1
+alert.severity = 4
+alert.suppress = 0
+counttype = number of events
+quantity = 0
+relation = greater than
+cron_schedule =	*/31 * * * *
+description = This alert will show the successful login outside US. \
+\
+Data Collection - Office 365 management activity data (Splunk Add-on for Office 365). 
+dispatch.earliest_time = -55m@s
+dispatch.latest_time = -25m@s
+display.general.type = statistics
+display.page.search.tab = statistics
+display.page.search.mode = fast
+request.ui_dispatch_app = cyences_app_for_splunk
+request.ui_dispatch_view = search
+search = `cs_o365` sourcetype="o365:management:activity" Workload=AzureActiveDirectory Operation=UserLoggedIn NOT LogonError=* \
+| stats count, max(_time) as Last_Success_Login by user, ClientIP \
+| iplocation ClientIP \
+| where Country!=`cs_home_country` \
+| `confirmiplocation` \
+| fillnull Country, Region, City value="-" \
+| eval Location=ClientIP." (".count.") | ".Country." | ".Region." | ".City \
+| stats sum(count) as count, max(Last_Success_Login) as Last_Success_Login, list(Location) as Location by user \
+| sort - count \
+| `cs_human_readable_time_format(Last_Success_Login)` \
+| `cs_o365_success_login_outside_country_filter`
+action.summary_index = 1
+action.summary_index._name = cyences
+action.summary_index.category = O365
+action.summary_index.alert_name = O365 - Successful login outside US
+
+[O365 - Authentication blocked by conditional access policy]
+disabled = 1
+enableSched = 1
+alert.track = 1
+alert.severity = 4
+alert.suppress = 0
+counttype = number of events
+quantity = 0
+relation = greater than
+cron_schedule =	29 * * * *
+description = This alert will show the authentication blocked by conditional access policy. \
+\
+Data Collection - Office 365 management activity data (Splunk Add-on for Office 365). 
+dispatch.earliest_time = -85m@s
+dispatch.latest_time = -25m@s
+display.general.type = statistics
+display.page.search.tab = statistics
+display.page.search.mode = fast
+request.ui_dispatch_app = cyences_app_for_splunk
+request.ui_dispatch_view = search
+search = `cs_o365` sourcetype="o365:management:activity" Workload=AzureActiveDirectory Operation=UserLoginFailed LogonError="BlockedByConditionalAccess" \
+| eval ExtendedProperties=mvzip('ExtendedProperties{}.Name','ExtendedProperties{}.Value'," : ") \
+| stats count, max(_time) as Last_Failed_Login, values(ExtendedProperties) as ExtendedProperties by user, ClientIP \
+| iplocation ClientIP \
+| fillnull Country, Region, City value="-" \
+| eval Location=ClientIP." (".count.") | ".Country." | ".Region." | ".City \
+| stats sum(count) as count, max(Last_Failed_Login) as Last_Failed_Login, list(Location) as Location, values(ExtendedProperties) as ExtendedProperties by user \
+| sort - count \
+| `cs_human_readable_time_format(Last_Failed_Login)` \
+| `cs_o365_failed_login_due_to_conditional_access_policy_filter`
+action.summary_index = 1
+action.summary_index._name = cyences
+action.summary_index.category = O365
+action.summary_index.alert_name = O365 - Authentication blocked by conditional access policy
+
+[O365 - Daily Login failure]
+disabled = 1
+enableSched = 1
+alert.track = 1
+alert.severity = 4
+alert.suppress = 0
+counttype = number of events
+quantity = 0
+relation = greater than
+cron_schedule =	0 1 * * *
+description = This alert will show the daily Login failure. \
+\
+Data Collection - Office 365 management activity data (Splunk Add-on for Office 365). 
+dispatch.earliest_time = -25h@m
+dispatch.latest_time = -1h@m
+display.general.type = statistics
+display.page.search.tab = statistics
+display.page.search.mode = fast
+request.ui_dispatch_app = cyences_app_for_splunk
+request.ui_dispatch_view = search
+search = `cs_o365` sourcetype="o365:management:activity" Workload=AzureActiveDirectory Operation=UserLoginFailed \
+| eval ExtendedProperties=mvzip('ExtendedProperties{}.Name','ExtendedProperties{}.Value'," : ") \
+| stats count, max(_time) as Last_Failed_Login, values(LogonError) as LogonError, values(ExtendedProperties) as ExtendedProperties by user, ClientIP \
+| iplocation ClientIP \
+| fillnull Country, Region, City value="-" \
+| eval Location=ClientIP." (".count.") | ".Country." | ".Region." | ".City \
+| stats sum(count) as count, max(Last_Failed_Login) as Last_Failed_Login, list(Location) as Location, values(LogonError) as LogonError, values(ExtendedProperties) as ExtendedProperties by user \
+| sort - count \
+| `cs_human_readable_time_format(Last_Failed_Login)` \
+| `cs_o365_daily_login_failure_filter`
+action.summary_index = 1
+action.summary_index._name = cyences
+action.summary_index.category = O365
+action.summary_index.alert_name = O365 - Daily Login failure
+
 
 # ======================
 # Credential Compromise

--- a/cyences_app_for_splunk/default/savedsearches.conf
+++ b/cyences_app_for_splunk/default/savedsearches.conf
@@ -1531,7 +1531,7 @@ alert.suppress = 0
 counttype = number of events
 quantity = 0
 relation = greater than
-cron_schedule =	*/31 * * * *
+cron_schedule =	9,39 * * * *
 description = This alert will show the login failure outside home country due to multi factor authentication. \
 \
 Data Collection - Office 365 management activity data (Splunk Add-on for Office 365). 
@@ -1568,7 +1568,7 @@ alert.suppress = 0
 counttype = number of events
 quantity = 0
 relation = greater than
-cron_schedule =	*/31 * * * *
+cron_schedule =	9,39 * * * *
 description = This alert will show the Login from unknown user. \
 \
 Data Collection - Office 365 management activity data (Splunk Add-on for Office 365). 
@@ -1599,7 +1599,7 @@ alert.suppress = 0
 counttype = number of events
 quantity = 0
 relation = greater than
-cron_schedule =	*/31 * * * *
+cron_schedule =	9,39 * * * *
 description = This alert will show the successful login outside home country. \
 \
 Data Collection - Office 365 management activity data (Splunk Add-on for Office 365). 

--- a/cyences_app_for_splunk/default/savedsearches.conf
+++ b/cyences_app_for_splunk/default/savedsearches.conf
@@ -1487,7 +1487,7 @@ action.summary_index._name = cyences
 action.summary_index.category = O365
 action.summary_index.alert_name = O365 - Application Change/Update
 
-[O365 - Login failure due to multi factor authentication]
+[O365 - Login Failure Due To Multi Factor Authentication]
 disabled = 1
 enableSched = 1
 alert.track = 1
@@ -1520,9 +1520,9 @@ search = `cs_o365` sourcetype="o365:management:activity" Workload=AzureActiveDir
 action.summary_index = 1
 action.summary_index._name = cyences
 action.summary_index.category = O365
-action.summary_index.alert_name = O365 - Login failure due to multi factor authentication
+action.summary_index.alert_name = O365 - Login Failure Due To Multi Factor Authentication
 
-[O365 - Login failure outside US due to multi factor authentication]
+[O365 - Login Failure Outside Home Country Due To Multi Factor Authentication]
 disabled = 1
 enableSched = 1
 alert.track = 1
@@ -1532,7 +1532,7 @@ counttype = number of events
 quantity = 0
 relation = greater than
 cron_schedule =	*/31 * * * *
-description = This alert will show the login failure outside US due to multi factor authentication. \
+description = This alert will show the login failure outside home country due to multi factor authentication. \
 \
 Data Collection - Office 365 management activity data (Splunk Add-on for Office 365). 
 dispatch.earliest_time = -55m@s
@@ -1547,7 +1547,7 @@ search = `cs_o365` sourcetype="o365:management:activity" Workload=AzureActiveDir
 | stats count, max(_time) as Last_Failed_Login, values(LogonError) as LogonError, values(ExtendedProperties) as ExtendedProperties by user, ClientIP \
 | iplocation ClientIP \
 | where Country!=`cs_home_country` \
-| `confirmiplocation` \
+| `cs_confirmiplocation` \
 | fillnull Country, Region, City value="-" \
 | eval Location=ClientIP." (".count.") | ".Country." | ".Region." | ".City \
 | stats sum(count) as count, max(Last_Failed_Login) as Last_Failed_Login, list(Location) as Location, values(LogonError) as LogonError, values(ExtendedProperties) as ExtendedProperties by user \
@@ -1557,9 +1557,9 @@ search = `cs_o365` sourcetype="o365:management:activity" Workload=AzureActiveDir
 action.summary_index = 1
 action.summary_index._name = cyences
 action.summary_index.category = O365
-action.summary_index.alert_name = O365 - Login failure outside US due to multi factor authentication
+action.summary_index.alert_name = O365 - Login Failure Outside Home Country Due To Multi Factor Authentication
 
-[O365 - Login from unknown user]
+[O365 - Login From Unknown User]
 disabled = 1
 enableSched = 1
 alert.track = 1
@@ -1588,9 +1588,9 @@ search = `cs_o365` sourcetype="o365:management:activity" Workload=AzureActiveDir
 action.summary_index = 1
 action.summary_index._name = cyences
 action.summary_index.category = O365
-action.summary_index.alert_name = O365 - Login from unknown user
+action.summary_index.alert_name = O365 - Login From Unknown User
 
-[O365 - Successful login outside US]
+[O365 - Successful Login Outside Home Country]
 disabled = 1
 enableSched = 1
 alert.track = 1
@@ -1600,7 +1600,7 @@ counttype = number of events
 quantity = 0
 relation = greater than
 cron_schedule =	*/31 * * * *
-description = This alert will show the successful login outside US. \
+description = This alert will show the successful login outside home country. \
 \
 Data Collection - Office 365 management activity data (Splunk Add-on for Office 365). 
 dispatch.earliest_time = -55m@s
@@ -1614,7 +1614,7 @@ search = `cs_o365` sourcetype="o365:management:activity" Workload=AzureActiveDir
 | stats count, max(_time) as Last_Success_Login by user, ClientIP \
 | iplocation ClientIP \
 | where Country!=`cs_home_country` \
-| `confirmiplocation` \
+| `cs_confirmiplocation` \
 | fillnull Country, Region, City value="-" \
 | eval Location=ClientIP." (".count.") | ".Country." | ".Region." | ".City \
 | stats sum(count) as count, max(Last_Success_Login) as Last_Success_Login, list(Location) as Location by user \
@@ -1624,9 +1624,9 @@ search = `cs_o365` sourcetype="o365:management:activity" Workload=AzureActiveDir
 action.summary_index = 1
 action.summary_index._name = cyences
 action.summary_index.category = O365
-action.summary_index.alert_name = O365 - Successful login outside US
+action.summary_index.alert_name = O365 - Successful Login Outside Home Country
 
-[O365 - Authentication blocked by conditional access policy]
+[O365 - Authentication Blocked By Conditional Access Policy]
 disabled = 1
 enableSched = 1
 alert.track = 1
@@ -1659,9 +1659,9 @@ search = `cs_o365` sourcetype="o365:management:activity" Workload=AzureActiveDir
 action.summary_index = 1
 action.summary_index._name = cyences
 action.summary_index.category = O365
-action.summary_index.alert_name = O365 - Authentication blocked by conditional access policy
+action.summary_index.alert_name = O365 - Authentication Blocked By Conditional Access Policy
 
-[O365 - Daily Login failure]
+[O365 - Daily Login Failure]
 disabled = 1
 enableSched = 1
 alert.track = 1
@@ -1694,7 +1694,7 @@ search = `cs_o365` sourcetype="o365:management:activity" Workload=AzureActiveDir
 action.summary_index = 1
 action.summary_index._name = cyences
 action.summary_index.category = O365
-action.summary_index.alert_name = O365 - Daily Login failure
+action.summary_index.alert_name = O365 - Daily Login Failure
 
 
 # ======================


### PR DESCRIPTION
CY-317: Add below alerts and it's filter macro
| Name | Cron |
|--------|-------|
| O365 - Login Failure Due To Multi Factor Authentication | Runs every hour |
| O365 - Login Failure Outside Home Country Due To Multi Factor Authentication | Runs every 30 minute |
| O365 - Login From Unknown User | Runs every 30 minute |
| O365 - Successful Login Outside Home Country | Runs every 30 minute |
| O365 - Authentication Blocked By Conditional Access Policy | Runs every hour |
| O365 - Daily Login Failure | Runs every day |

Note: The average time difference between _indextime and _time is around 25 minute so the latest and earliest time is set accrodingly in alerts.