### PR TITLE
Show the antivirus field detail in lansweeper dashboard as per new data collection

### DIFF
--- a/cyences_app_for_splunk/default/data/ui/views/cs_asset_intelligence.xml
+++ b/cyences_app_for_splunk/default/data/ui/views/cs_asset_intelligence.xml
@@ -100,9 +100,13 @@
       <title>Lansweeper $tkn_filter_main_label$</title>
       <table>
         <search>
-          <query>`cs_lansweeper` `cs_lansweeper_timerange` | rename IPAddress as ip, AssetName as host, Username as user | search $tkn_filter_main$ | eval id=coalesce(AssetID,id) | dedup id
-| rename AssetTypename as Type, Statename as State, Userdomain as Domain, AssetGroup as GroupName, Mac as MacAddress, OScode as OSVersion, Firstseen as FirstSeen, Lastseen as LastSeen, LastChanged as LastChanged 
-| table id, ip, host, user, MacAddress, State, Type, OS, OSVersion, OSRelease, OSname, SystemVersion, version, FQDN, GroupName, IPLocation, Domain, AssetDomain, Memory, Processor, Manufacturer, Model, Serialnumber, BuildNumber, LsAgentVersion, LastLsAgent, FirstSeen, LastSeen, LastChanged, Description</query>
+          <query>`cs_lansweeper` `cs_lansweeper_timerange` | rename IPAddress as ip, AssetName as host, Username as user | search $tkn_filter_main$ | eval id=coalesce(AssetID,id) 
+| rename AssetTypename as Type, Statename as State, Userdomain as Domain, AssetGroup as GroupName, Mac as MacAddress, OScode as OSVersion, Firstseen as FirstSeen, Lastseen as LastSeen 
+| eval antivirus = antivirus_name."#".antivirus_enabled 
+| table id, site_name, ip, host, user, MacAddress, State, Type, OS, OSVersion, OSRelease, OSname, SystemVersion, version, FQDN, GroupName, IPLocation, Domain, AssetDomain, Memory, Processor, Manufacturer, Model, Serialnumber, BuildNumber, LsAgentVersion, LastLsAgent, FirstSeen, LastSeen, LastChanged, Description, antivirus
+| stats values(GroupName) as GroupName, values(antivirus) as antivirus, values(Processor) as Processor, first(*) as * by id 
+| rex field=antivirus max_match=0 "(?&lt;antivirus_name&gt;[^#]+)#(?&lt;antivirus_enabled&gt;[^\n]+)"
+| table id, site_name, ip, host, user, MacAddress, State, Type, OS, OSVersion, OSRelease, OSname, antivirus_name, antivirus_enabled, SystemVersion, version, FQDN, GroupName, IPLocation, Domain, AssetDomain, Memory, Processor, Manufacturer, Model, Serialnumber, BuildNumber, LsAgentVersion, LastLsAgent, FirstSeen, LastSeen, LastChanged, Description</query>
           <earliest>0</earliest>
           <latest></latest>
         </search>
@@ -112,11 +116,13 @@
     </panel>
   </row>
   <row>
+    <panel>
     <html>
       <div>
         <p>To see network telemetry on this devices, please click <a href="/app/cyences_app_for_splunk/cs_network_reports?form.tkn_ip=$tkn_ip_tmp$" target="_black">here</a>.</p>
       </div>
     </html>
+    </panel>
   </row>
   <row depends="$tkn_show_hide_qualys$">
     <panel>

--- a/cyences_app_for_splunk/default/data/ui/views/cs_asset_intelligence.xml
+++ b/cyences_app_for_splunk/default/data/ui/views/cs_asset_intelligence.xml
@@ -100,13 +100,13 @@
       <title>Lansweeper $tkn_filter_main_label$</title>
       <table>
         <search>
-          <query>`cs_lansweeper` `cs_lansweeper_timerange` | rename IPAddress as ip, AssetName as host, Username as user | search $tkn_filter_main$ | eval id=coalesce(AssetID,id) 
-| rename AssetTypename as Type, Statename as State, Userdomain as Domain, AssetGroup as GroupName, Mac as MacAddress, OScode as OSVersion, Firstseen as FirstSeen, Lastseen as LastSeen 
-| eval antivirus = mvzip(antivirus_name, antivirus_enabled, "#") 
-| table id, site_name, ip, host, user, MacAddress, State, Type, OS, OSVersion, OSRelease, OSname, SystemVersion, version, FQDN, GroupName, IPLocation, Domain, AssetDomain, Memory, Processor, Manufacturer, Model, Serialnumber, BuildNumber, LsAgentVersion, LastLsAgent, FirstSeen, LastSeen, LastChanged, Description, antivirus
-| stats values(GroupName) as GroupName, values(antivirus) as antivirus, values(Processor) as Processor, first(*) as * by id 
-| rex field=antivirus max_match=0 "(?&lt;antivirus_name&gt;[^#]+)#(?&lt;antivirus_enabled&gt;[^\n]+)"
-| table id, site_name, ip, host, user, MacAddress, State, Type, OS, OSVersion, OSRelease, OSname, antivirus_name, antivirus_enabled, SystemVersion, version, FQDN, GroupName, IPLocation, Domain, AssetDomain, Memory, Processor, Manufacturer, Model, Serialnumber, BuildNumber, LsAgentVersion, LastLsAgent, FirstSeen, LastSeen, LastChanged, Description</query>
+          <query>| inputlookup cs_lansweeper_inventory 
+| search $tkn_filter_main$ 
+| eval active_antivirus_mix = mvfilter(match(antivirus, "(1|true)$")) 
+| rex field=active_antivirus_mix max_match=0 "(?&lt;active_antivirus&gt;[^#]+)#(?&lt;antivirus_enabled&gt;[^\n]+)" 
+| rename AssetName as host, lansweeper_user as user, lansweeper_id as id, AssetType as Type, lansweeper_state as State, mac_address as MacAddress, lansweeper_os as OS, AssetVersion as version, lansweeper_fqdn as FQDN 
+| table id, ip, host, user, MacAddress, State, Type, OS, OSVersion, OSRelease, OSname, active_antivirus, SystemVersion, version, FQDN, GroupName, IPLocation, Domain, AssetDomain, Memory, Processor, Manufacturer, Model, Serialnumber, BuildNumber, LsAgentVersion, LastLsAgent, FirstSeen, LastSeen, LastChanged, Description 
+| eval active_antivirus = mvjoin(active_antivirus, " &amp; ")</query>
           <earliest>0</earliest>
           <latest></latest>
         </search>
@@ -117,11 +117,11 @@
   </row>
   <row>
     <panel>
-    <html>
-      <div>
-        <p>To see network telemetry on this devices, please click <a href="/app/cyences_app_for_splunk/cs_network_reports?form.tkn_ip=$tkn_ip_tmp$" target="_black">here</a>.</p>
-      </div>
-    </html>
+      <html>
+        <div>
+          <p>To see network telemetry on this devices, please click <a href="/app/cyences_app_for_splunk/cs_network_reports?form.tkn_ip=$tkn_ip_tmp$" target="_black">here</a>.</p>
+        </div>
+      </html>
     </panel>
   </row>
   <row depends="$tkn_show_hide_qualys$">

--- a/cyences_app_for_splunk/default/data/ui/views/cs_asset_intelligence.xml
+++ b/cyences_app_for_splunk/default/data/ui/views/cs_asset_intelligence.xml
@@ -102,7 +102,7 @@
         <search>
           <query>`cs_lansweeper` `cs_lansweeper_timerange` | rename IPAddress as ip, AssetName as host, Username as user | search $tkn_filter_main$ | eval id=coalesce(AssetID,id) 
 | rename AssetTypename as Type, Statename as State, Userdomain as Domain, AssetGroup as GroupName, Mac as MacAddress, OScode as OSVersion, Firstseen as FirstSeen, Lastseen as LastSeen 
-| eval antivirus = antivirus_name."#".antivirus_enabled 
+| eval antivirus = mvzip(antivirus_name, antivirus_enabled, "#") 
 | table id, site_name, ip, host, user, MacAddress, State, Type, OS, OSVersion, OSRelease, OSname, SystemVersion, version, FQDN, GroupName, IPLocation, Domain, AssetDomain, Memory, Processor, Manufacturer, Model, Serialnumber, BuildNumber, LsAgentVersion, LastLsAgent, FirstSeen, LastSeen, LastChanged, Description, antivirus
 | stats values(GroupName) as GroupName, values(antivirus) as antivirus, values(Processor) as Processor, first(*) as * by id 
 | rex field=antivirus max_match=0 "(?&lt;antivirus_name&gt;[^#]+)#(?&lt;antivirus_enabled&gt;[^\n]+)"

--- a/cyences_app_for_splunk/default/data/ui/views/cs_lansweeper.xml
+++ b/cyences_app_for_splunk/default/data/ui/views/cs_lansweeper.xml
@@ -8,7 +8,7 @@
   <label>Lansweeper</label>
   <search id="search_windows_assets">
     <query>`cs_lansweeper` `cs_lansweeper_timerange` AssetTypename="Windows" | eval id=coalesce(AssetID,id)
-| eval antivirus = antivirus_name."#".antivirus_enabled 
+| eval antivirus = mvzip(antivirus_name, antivirus_enabled, "#") 
 | rename site_name as Site, AssetName as Name, AssetTypename as Type, Statename as State, Userdomain as Domain, AssetGroup as GroupName, Mac as MacAddress, OScode as OSVersion, Username as User 
 | table id, antivirus, Site, Name,Description, State, Domain, IPAddress, MacAddress,IPLocation,FQDN ,OS, OSVersion, User
 | stats values(antivirus) as antivirus, first(*) as * by id 

--- a/cyences_app_for_splunk/default/data/ui/views/cs_lansweeper.xml
+++ b/cyences_app_for_splunk/default/data/ui/views/cs_lansweeper.xml
@@ -7,7 +7,14 @@
   </init>
   <label>Lansweeper</label>
   <search id="search_windows_assets">
-    <query>`cs_lansweeper` `cs_lansweeper_timerange` AssetTypename="Windows" | eval id=coalesce(AssetID,id)  | dedup id | join type=left id [| search `cs_lansweeper` `cs_lansweeper_timerange` sourcetype="lansweeper:antivirus:onprem"| where onAccessScanningEnabled=1 | stats latest(DisplayName) as active_antivirus by AssetID | rename AssetID as id]| rename site_name as Site, AssetName as Name, AssetTypename as Type, Statename as State, Userdomain as Domain, AssetGroup as GroupName, Mac as MacAddress, OScode as OSVersion, Username as User | table Site, Name,Description, State, Domain, IPAddress, MacAddress,IPLocation,FQDN ,OS, OSVersion, User, active_antivirus | eval name_lower=lower(Name)
+    <query>`cs_lansweeper` `cs_lansweeper_timerange` AssetTypename="Windows" | eval id=coalesce(AssetID,id)
+| eval antivirus = antivirus_name."#".antivirus_enabled 
+| rename site_name as Site, AssetName as Name, AssetTypename as Type, Statename as State, Userdomain as Domain, AssetGroup as GroupName, Mac as MacAddress, OScode as OSVersion, Username as User 
+| table id, antivirus, Site, Name,Description, State, Domain, IPAddress, MacAddress,IPLocation,FQDN ,OS, OSVersion, User
+| stats values(antivirus) as antivirus, first(*) as * by id 
+| eval active_antivirus_mix = mvfilter(match(antivirus, "(1|true)$"))
+| rex field=active_antivirus_mix max_match=0 "(?&lt;active_antivirus&gt;[^#]+)#(?&lt;antivirus_enabled&gt;[^\n]+)"
+| eval name_lower=lower(Name)
 | join type="left" name_lower [| tstats count where `cs_wineventlog_security` `cs_wineventlog_security_timerange` by host  | table host | rename host as name_lower | eval name_lower=lower(name_lower) | eval WinEventLog_Security="Present"]
 | join type="left" name_lower [| tstats count where `cs_wineventlog_system` `cs_wineventlog_system_timerange` by host | table host | rename host as name_lower | eval name_lower=lower(name_lower) | eval WinEventLog_System="Present"]
 | join type="left" name_lower [| tstats count where `cs_sysmon` `cs_sysmon_timerange` by host  | table host | rename host as name_lower | eval name_lower=lower(name_lower) | eval Sysmon="Present"]

--- a/cyences_app_for_splunk/default/data/ui/views/cs_lansweeper.xml
+++ b/cyences_app_for_splunk/default/data/ui/views/cs_lansweeper.xml
@@ -7,13 +7,12 @@
   </init>
   <label>Lansweeper</label>
   <search id="search_windows_assets">
-    <query>`cs_lansweeper` `cs_lansweeper_timerange` AssetTypename="Windows" | eval id=coalesce(AssetID,id)
-| eval antivirus = mvzip(antivirus_name, antivirus_enabled, "#") 
-| rename site_name as Site, AssetName as Name, AssetTypename as Type, Statename as State, Userdomain as Domain, AssetGroup as GroupName, Mac as MacAddress, OScode as OSVersion, Username as User 
-| table id, antivirus, Site, Name,Description, State, Domain, IPAddress, MacAddress,IPLocation,FQDN ,OS, OSVersion, User
-| stats values(antivirus) as antivirus, first(*) as * by id 
+    <query>| inputlookup cs_lansweeper_inventory 
+| search AssetType="Windows" 
+| rename lansweeper_id as id, AssetName as Name, AssetType as Type, lansweeper_state as State, mac_address as MacAddress, AssetVersion as Version, lansweeper_user as User, ip as IPAddress, lansweeper_fqdn as FQDN, lansweeper_os as OS
 | eval active_antivirus_mix = mvfilter(match(antivirus, "(1|true)$"))
 | rex field=active_antivirus_mix max_match=0 "(?&lt;active_antivirus&gt;[^#]+)#(?&lt;antivirus_enabled&gt;[^\n]+)"
+| table Site, Name, Description, State, Domain, IPAddress, MacAddress, IPLocation, FQDN, OS, OSVersion, User, active_antivirus
 | eval name_lower=lower(Name)
 | join type="left" name_lower [| tstats count where `cs_wineventlog_security` `cs_wineventlog_security_timerange` by host  | table host | rename host as name_lower | eval name_lower=lower(name_lower) | eval WinEventLog_Security="Present"]
 | join type="left" name_lower [| tstats count where `cs_wineventlog_system` `cs_wineventlog_system_timerange` by host | table host | rename host as name_lower | eval name_lower=lower(name_lower) | eval WinEventLog_System="Present"]
@@ -22,26 +21,35 @@
 | join type=left IPAddress [| inputlookup cs_tenable_inventory | makemv ip delim="~~" | mvexpand ip | dedup ip | table ip | rename ip as IPAddress | eval Tenable="Present"]
 | join type=left name_lower [| inputlookup cs_tenable_inventory | makemv hostname delim="~~" | mvexpand hostname | dedup hostname | table hostname | rename hostname as name_lower | eval Tenable="Present"]
 | fillnull WinEventLog_Security, WinEventLog_System, Sysmon, Qualys, Tenable value="Absent"
-| table Site, Name,Description,State,  IPAddress, MacAddress,IPLocation,FQDN ,OS, OSVersion, Domain,User,active_antivirus, WinEventLog_Security, WinEventLog_System, Sysmon, Qualys, Tenable
-| sort Name </query>
+| table Site, Name, Description, State, IPAddress, MacAddress, IPLocation, FQDN , OS, OSVersion, Domain, User, active_antivirus, WinEventLog_Security, WinEventLog_System, Sysmon, Qualys, Tenable
+| eval active_antivirus = mvjoin(active_antivirus, " &amp; ")
+| sort Name</query>
     <earliest>-4h@m</earliest>
     <latest>now</latest>
     <sampleRatio>1</sampleRatio>
   </search>
   <search id="search_vmware_server_assets">
-    <query>`cs_lansweeper` `cs_lansweeper_timerange`  (AssetTypename="VMware vCenter server" OR AssetTypename="ESXi server") | eval id=coalesce(AssetID,id) | dedup id | rename site_name as Site, AssetName as Name, AssetTypename as Type, Statename as State, Userdomain as Domain, AssetGroup as GroupName, Mac as MacAddress, OScode as OSVersion, version as Version,Username as User | table Site, Type, Name, State, Domain, Version, IPAddress, MacAddress, OSVersion, User,OS,IPLocation,Description, FQDN | eval name_lower=lower(Name)
+    <query>| inputlookup cs_lansweeper_inventory 
+| search (AssetType="VMware vCenter server" OR AssetType="ESXi server") 
+| rename lansweeper_id as id, AssetName as Name, AssetType as Type, lansweeper_state as State, mac_address as MacAddress, AssetVersion as Version, lansweeper_user as User, ip as IPAddress, lansweeper_fqdn as FQDN, lansweeper_os as OS
+| table Site, Type, Name, State, Domain, Version, IPAddress, MacAddress, OSVersion, User, OS, IPLocation, Description, FQDN 
+| eval name_lower=lower(Name)
 | join type=left IPAddress [| search `cs_qualys_hostsummary` OS="VMware *" `cs_qualys_timerange` | dedup IP | table IP | rename IP as IPAddress | eval Qualys="Present"]
 | join type=left IPAddress [| inputlookup cs_tenable_inventory | makemv ip delim="~~" | mvexpand ip | dedup ip | table ip | rename ip as IPAddress | eval Tenable="Present"]
 | join type=left name_lower [| inputlookup cs_tenable_inventory | makemv hostname delim="~~" | mvexpand hostname | dedup hostname | table hostname | rename hostname as name_lower | eval Tenable="Present"]
 | fillnull Qualys, Tenable value="Absent"
-| table Site, Name,Description,State,  IPAddress, MacAddress,IPLocation,FQDN ,Type,OS, OSVersion,Version, Qualys, Tenable
+| table Site, Name, Description, State, IPAddress, MacAddress, IPLocation, FQDN , Type, OS, OSVersion, Version, Qualys, Tenable
 | sort Name</query>
     <earliest>-4h@m</earliest>
     <latest>now</latest>
     <sampleRatio>1</sampleRatio>
   </search>
   <search id="search_vmware_guest_assets">
-    <query>`cs_lansweeper` `cs_lansweeper_timerange` AssetTypename IN ("VMware Guest", "Hyper-V guest") | eval id=coalesce(AssetID,id) | dedup id | rename site_name as Site, AssetName as Name, AssetTypename as Type, Statename as State, Userdomain as Domain, AssetGroup as GroupName, Mac as MacAddress, OScode as OSVersion, Username as User | table Site, Type, Name, State, Domain, Version, IPAddress, MacAddress, OSVersion, User,OS,IPLocation,Description, FQDN | eval name_lower=lower(Name)
+    <query>| inputlookup cs_lansweeper_inventory 
+| search AssetType IN ("VMware Guest", "Hyper-V guest") 
+| rename lansweeper_id as id, AssetName as Name, AssetType as Type, lansweeper_state as State, mac_address as MacAddress, AssetVersion as Version, lansweeper_user as User, ip as IPAddress, lansweeper_fqdn as FQDN, lansweeper_os as OS
+| table Site, Type, Name, State, Domain, Version, IPAddress, MacAddress, OSVersion, User, OS, IPLocation, Description, FQDN 
+| eval name_lower=lower(Name)
 | join type="left" name_lower [| tstats count where `cs_wineventlog_security` `cs_wineventlog_security_timerange` by host  | table host | rename host as name_lower | eval name_lower=lower(name_lower) | eval WinEventLog_Security="Present"]
 | join type="left" name_lower [| tstats count where `cs_wineventlog_system` `cs_wineventlog_system_timerange` by host | table host | rename host as name_lower | eval name_lower=lower(name_lower) | eval WinEventLog_System="Present"]
 | join type="left" name_lower [| tstats count where `cs_sysmon` `cs_sysmon_timerange` by host | table host | rename host as name_lower | eval name_lower=lower(name_lower) | eval Sysmon="Present"]
@@ -50,83 +58,109 @@
 | join type=left name_lower [| inputlookup cs_tenable_inventory | makemv hostname delim="~~" | mvexpand hostname | dedup hostname | table hostname, tenable_os | rename hostname as name_lower | eval Tenable="Present"]
 | eval OS=coalesce(OS, tenable_os)
 | fillnull WinEventLog_Security, WinEventLog_System, Sysmon, Qualys, Tenable value="Absent"
-| table Site, Name,Description,State,  IPAddress, MacAddress,IPLocation,FQDN , Type,OS, WinEventLog_Security, WinEventLog_System, Sysmon, Qualys, Tenable
+| table Site, Name, Description, State, IPAddress, MacAddress, IPLocation, FQDN , Type, OS, WinEventLog_Security, WinEventLog_System, Sysmon, Qualys, Tenable
 | sort Name</query>
     <earliest>-4h@m</earliest>
     <latest>now</latest>
     <sampleRatio>1</sampleRatio>
   </search>
   <search id="search_linux_assets">
-    <query>`cs_lansweeper` `cs_lansweeper_timerange` AssetTypename="Linux" | eval id=coalesce(AssetID,id) | dedup id | rename site_name as Site, AssetName as Name, AssetTypename as Type, Statename as State, Userdomain as Domain, AssetGroup as GroupName, Mac as MacAddress, OScode as OSVersion,Username as User | table Site, Name, State, Domain, IPAddress, MacAddress, OSVersion, User,OS,IPLocation,Description, FQDN | eval name_lower=lower(Name)
+    <query>| inputlookup cs_lansweeper_inventory 
+| search AssetType="Linux" 
+| rename lansweeper_id as id, AssetName as Name, AssetType as Type, lansweeper_state as State, mac_address as MacAddress, AssetVersion as Version, lansweeper_user as User, ip as IPAddress, lansweeper_fqdn as FQDN, lansweeper_os as OS
+| eval active_antivirus_mix = mvfilter(match(antivirus, "(1|true)$"))
+| rex field=active_antivirus_mix max_match=0 "(?&lt;active_antivirus&gt;[^#]+)#(?&lt;antivirus_enabled&gt;[^\n]+)"
+| table Site, Name, State, Domain, IPAddress, MacAddress, OSVersion, User, OS, IPLocation, Description, FQDN, active_antivirus 
+| eval name_lower=lower(Name)
 | join type=left IPAddress [| search `cs_qualys_hostsummary` OS IN `cs_qualys_linux_os` `cs_qualys_timerange` | dedup IP | table IP, OS | rename IP as IPAddress | eval Qualys="Present"]
 | join type=left IPAddress [| inputlookup cs_tenable_inventory | makemv ip delim="~~" | mvexpand ip | dedup ip | table ip, tenable_os | rename ip as IPAddress | eval Tenable="Present"]
 | join type=left name_lower [| inputlookup cs_tenable_inventory | makemv hostname delim="~~" | mvexpand hostname | dedup hostname | table hostname, tenable_os | rename hostname as name_lower | eval Tenable="Present"]
 | eval OS=coalesce(OS, tenable_os)
 | fillnull Qualys, Tenable value="Absent"
-| table Site, Name,Description,State, IPAddress, MacAddress,IPLocation,FQDN ,OS, Qualys, Tenable
+| table Site, Name, Description, State, IPAddress, MacAddress, IPLocation, FQDN , OS, active_antivirus, Qualys, Tenable
+| eval active_antivirus = mvjoin(active_antivirus, " &amp; ")
 | sort Name</query>
     <earliest>-4h@m</earliest>
     <latest>now</latest>
     <sampleRatio>1</sampleRatio>
   </search>
   <search id="search_mac_assets">
-    <query>`cs_lansweeper` `cs_lansweeper_timerange` AssetTypename="Apple Mac" | eval id=coalesce(AssetID,id) | dedup id | rename site_name as Site, AssetName as Name, AssetTypename as Type, Statename as State, Userdomain as Domain, AssetGroup as GroupName, Mac as MacAddress, OScode as OSVersion,Username as User | table Site, Name, State, Domain, IPAddress, MacAddress, OSVersion, User,OS,IPLocation,Description, FQDN | eval name_lower=lower(Name)
+    <query>| inputlookup cs_lansweeper_inventory 
+| search AssetType="Apple Mac" 
+| rename lansweeper_id as id, AssetName as Name, AssetType as Type, lansweeper_state as State, mac_address as MacAddress, AssetVersion as Version, lansweeper_user as User, ip as IPAddress, lansweeper_fqdn as FQDN, lansweeper_os as OS
+| eval active_antivirus_mix = mvfilter(match(antivirus, "(1|true)$"))
+| rex field=active_antivirus_mix max_match=0 "(?&lt;active_antivirus&gt;[^#]+)#(?&lt;antivirus_enabled&gt;[^\n]+)"
+| table Site, Name, State, Domain, IPAddress, MacAddress, OSVersion, User, OS, IPLocation, Description, FQDN, active_antivirus 
+| eval name_lower=lower(Name)
 | join type=left IPAddress [| search `cs_qualys_hostsummary` OS IN `cs_qualys_linux_os` `cs_qualys_timerange` | dedup IP | table IP, OS | rename IP as IPAddress | eval Qualys="Present"]
 | join type=left IPAddress [| inputlookup cs_tenable_inventory | makemv ip delim="~~" | mvexpand ip | dedup ip | table ip, tenable_os | rename ip as IPAddress | eval Tenable="Present"]
 | join type=left name_lower [| inputlookup cs_tenable_inventory | makemv hostname delim="~~" | mvexpand hostname | dedup hostname | table hostname, tenable_os | rename hostname as name_lower | eval Tenable="Present"]
 | eval OS=coalesce(OS, tenable_os)
 | fillnull Qualys, Tenable value="Absent"
-| table Site, Name, Description, State, IPAddress, MacAddress, IPLocation, FQDN ,OS, User, Qualys, Tenable
+| table Site, Name, Description, State, IPAddress, MacAddress, IPLocation, FQDN , OS, User, active_antivirus, Qualys, Tenable
+| eval active_antivirus = mvjoin(active_antivirus, " &amp; ")
 | sort Name</query>
     <earliest>-4h@m</earliest>
     <latest>now</latest>
     <sampleRatio>1</sampleRatio>
   </search>
   <search id="search_network_assets">
-    <query>`cs_lansweeper` `cs_lansweeper_timerange` AssetTypename="Network device" | eval id=coalesce(AssetID,id) | dedup id | rename site_name as Site, AssetName as Name, AssetTypename as Type, Statename as State, Userdomain as Domain, AssetGroup as GroupName, Mac as MacAddress, OScode as OSVersion, Username as User | eval name_lower=lower(Name)
-  | join type=left IPAddress [| search `cs_qualys_hostsummary` OS IN `cs_qualys_linux_os` `cs_qualys_timerange` | dedup IP | table IP, OS | rename IP as IPAddress | eval Qualys="Present"]
+    <query>| inputlookup cs_lansweeper_inventory 
+| search AssetType="Network device" 
+| rename lansweeper_id as id, AssetName as Name, AssetType as Type, lansweeper_state as State, mac_address as MacAddress, AssetVersion as Version, lansweeper_user as User, ip as IPAddress, lansweeper_fqdn as FQDN, lansweeper_os as OS
+| eval name_lower=lower(Name)
+| join type=left IPAddress [| search `cs_qualys_hostsummary` OS IN `cs_qualys_linux_os` `cs_qualys_timerange` | dedup IP | table IP, OS | rename IP as IPAddress | eval Qualys="Present"]
 | join type=left IPAddress [| inputlookup cs_tenable_inventory | makemv ip delim="~~" | mvexpand ip | dedup ip | table ip, tenable_os | rename ip as IPAddress | eval Tenable="Present"]
 | join type=left name_lower [| inputlookup cs_tenable_inventory | makemv hostname delim="~~" | mvexpand hostname | dedup hostname | table hostname, tenable_os | rename hostname as name_lower | eval Tenable="Present"]
 | eval OS=coalesce(OS, tenable_os)
 | fillnull Qualys, Tenable value="Absent"
 | table Site, Name, State, IPAddress, MacAddress, OS, DNSName, IPLocation, Qualys, Tenable
-| sort Name </query>
+| sort Name</query>
     <earliest>-4h@m</earliest>
     <latest>now</latest>
     <sampleRatio>1</sampleRatio>
   </search>
   <search id="search_webserver_assets">
-    <query>`cs_lansweeper` `cs_lansweeper_timerange` AssetTypename="Webserver" | eval id=coalesce(AssetID,id) | dedup id | rename site_name as Site, AssetName as Name, AssetTypename as Type, Statename as State, Userdomain as Domain, AssetGroup as GroupName, Mac as MacAddress, OScode as OSVersion, Username as User | eval name_lower=lower(Name)
-  | join type=left IPAddress [| search `cs_qualys_hostsummary` OS IN `cs_qualys_linux_os` `cs_qualys_timerange` | dedup IP | table IP, OS | rename IP as IPAddress | eval Qualys="Present"]
+    <query>| inputlookup cs_lansweeper_inventory 
+| search AssetType="Webserver" 
+| rename lansweeper_id as id, AssetName as Name, AssetType as Type, lansweeper_state as State, mac_address as MacAddress, AssetVersion as Version, lansweeper_user as User, ip as IPAddress, lansweeper_fqdn as FQDN, lansweeper_os as OS
+| eval name_lower=lower(Name)
+| join type=left IPAddress [| search `cs_qualys_hostsummary` OS IN `cs_qualys_linux_os` `cs_qualys_timerange` | dedup IP | table IP, OS | rename IP as IPAddress | eval Qualys="Present"]
 | join type=left IPAddress [| inputlookup cs_tenable_inventory | makemv ip delim="~~" | mvexpand ip | dedup ip | table ip, tenable_os | rename ip as IPAddress | eval Tenable="Present"]
 | join type=left name_lower [| inputlookup cs_tenable_inventory | makemv hostname delim="~~" | mvexpand hostname | dedup hostname | table hostname, tenable_os | rename hostname as name_lower | eval Tenable="Present"]
 | eval OS=coalesce(OS, tenable_os)
 | fillnull Qualys, Tenable value="Absent"
 | table Site, Name, State, IPAddress, MacAddress, OS, DNSName, IPLocation, Model, Qualys, Tenable
-| sort Name </query>
+| sort Name</query>
     <earliest>-4h@m</earliest>
     <latest>now</latest>
     <sampleRatio>1</sampleRatio>
   </search>
   <search id="search_location_assets">
-    <query>`cs_lansweeper` `cs_lansweeper_timerange` AssetTypename="Location" | eval id=coalesce(AssetID,id) | dedup id | rename site_name as Site, AssetName as Name, AssetTypename as Type, Statename as State, Userdomain as Domain, AssetGroup as GroupName, Mac as MacAddress, OScode as OSVersion, Username as User | table Site, Name, State, Domain, IPAddress, MacAddress, OSVersion, User
+    <query>| inputlookup cs_lansweeper_inventory 
+| search AssetType="Location" 
+| rename lansweeper_id as id, AssetName as Name, AssetType as Type, lansweeper_state as State, mac_address as MacAddress, AssetVersion as Version, lansweeper_user as User, ip as IPAddress, lansweeper_fqdn as FQDN, lansweeper_os as OS
 | table Site, Name, State
-| sort Name </query>
+| sort Name</query>
     <earliest>-4h@m</earliest>
     <latest>now</latest>
     <sampleRatio>1</sampleRatio>
   </search>
   <search id="search_monitor_assets">
-    <query>`cs_lansweeper` `cs_lansweeper_timerange` AssetTypename="Monitor" | eval id=coalesce(AssetID,id) | dedup id | rename site_name as Site, AssetName as Name, AssetTypename as Type, Statename as State, Userdomain as Domain, AssetGroup as GroupName, Mac as MacAddress, OScode as OSVersion, Username as User | table Site, Name, State, Domain, IPAddress, MacAddress, OSVersion, User
+    <query>| inputlookup cs_lansweeper_inventory 
+| search AssetType="Monitor" 
+| rename lansweeper_id as id, AssetName as Name, AssetType as Type, lansweeper_state as State, mac_address as MacAddress, AssetVersion as Version, lansweeper_user as User, ip as IPAddress, lansweeper_fqdn as FQDN, lansweeper_os as OS
 | table Site, Name, State
-| sort Name </query>
+| sort Name</query>
     <earliest>-4h@m</earliest>
     <latest>now</latest>
     <sampleRatio>1</sampleRatio>
   </search>
   <search id="search_other_assets">
-    <query>`cs_lansweeper` `cs_lansweeper_timerange` NOT AssetTypename IN ("Hyper-V guest", "VMware vCenter server", "ESXi server", "VMware Guest", "Windows", "Linux", "Apple Mac", "Network device", "Webserver", "Location", "Monitor") | eval id=coalesce(AssetID,id)  | dedup id | rename site_name as Site, AssetName as Name, AssetTypename as Type, Statename as State, Userdomain as Domain, AssetGroup as GroupName, Mac as MacAddress, OScode as OSVersion, Username as User | table Site, Type, Name, State, Domain, Version, IPAddress, MacAddress, OSVersion, User,OS,IPLocation,Description, FQDN
-| table Site, Name,Description,State, Domain, IPAddress, MacAddress,IPLocation,FQDN ,Type,OS, OSVersion, User
+    <query>| inputlookup cs_lansweeper_inventory 
+| search NOT AssetType IN ("Hyper-V guest", "VMware vCenter server", "ESXi server", "VMware Guest", "Windows", "Linux", "Apple Mac", "Network device", "Webserver", "Location", "Monitor")
+| rename lansweeper_id as id, AssetName as Name, AssetType as Type, lansweeper_state as State, mac_address as MacAddress, AssetVersion as Version, lansweeper_user as User, ip as IPAddress, lansweeper_fqdn as FQDN, lansweeper_os as OS
+| table Site, Name, Description, State, Domain, IPAddress, MacAddress, IPLocation, FQDN, Type, OS, OSVersion, User
 | sort Name</query>
     <earliest>-4h@m</earliest>
     <latest>now</latest>

--- a/cyences_app_for_splunk/default/savedsearches.conf
+++ b/cyences_app_for_splunk/default/savedsearches.conf
@@ -2311,9 +2311,11 @@ display.page.search.tab = statistics
 display.page.search.mode = fast
 request.ui_dispatch_app = cyences_app_for_splunk
 request.ui_dispatch_view = search
-search = `cs_lansweeper` `cs_lansweeper_timerange` | eval lansweeper_id=coalesce(AssetID,id) | dedup lansweeper_id \
+search = `cs_lansweeper` `cs_lansweeper_timerange` | eval lansweeper_id=coalesce(AssetID,id) \
 | eval fqdn=coalesce('assetBasicInfo.fqdn',FQDN) | eval hostname=lower(mvjoin(mvdedup(mvappend(AssetName, fqdn)),"~~")), ip=lower(IPAddress), mac_address=lower(Mac) \
-| rename _time as time, host as lansweeper_collected_by, site_name as Site, AssetTypename as AssetType, Statename as lansweeper_state, Userdomain as Domain, AssetGroup as GroupName, OScode as OSVersion, Username as lansweeper_user, BuildNumber as BuildNumber, version as AssetVersion, OS as lansweeper_os, fqdn as lansweeper_fqdn \
+| rename _time as time, host as lansweeper_collected_by, site_name as Site, AssetTypename as AssetType, Statename as lansweeper_state, Userdomain as Domain, AssetGroup as GroupName, OScode as OSVersion, Username as lansweeper_user, version as AssetVersion, OS as lansweeper_os, fqdn as lansweeper_fqdn \
+| table time, lansweeper_collected_by, hostname, ip, mac_address, lansweeper_id, Site, AssetType, lansweeper_state, Domain, GroupName, OSVersion, BuildNumber, AssetVersion, lansweeper_user, lansweeper_os, Description, IPLocation, lansweeper_fqdn \
+| stats values(GroupName) as GroupName, first(*) as * by lansweeper_id \
 | table time, lansweeper_collected_by, hostname, ip, mac_address, lansweeper_id, Site, AssetType, lansweeper_state, Domain, GroupName, OSVersion, BuildNumber, AssetVersion, lansweeper_user, lansweeper_os, Description, IPLocation, lansweeper_fqdn \
 | eval _key=lansweeper_id | outputlookup cs_lansweeper_inventory \
 | `cs_device_inventory_out_to_temp_lookup`

--- a/cyences_app_for_splunk/default/savedsearches.conf
+++ b/cyences_app_for_splunk/default/savedsearches.conf
@@ -2311,13 +2311,14 @@ display.page.search.tab = statistics
 display.page.search.mode = fast
 request.ui_dispatch_app = cyences_app_for_splunk
 request.ui_dispatch_view = search
-search = `cs_lansweeper` `cs_lansweeper_timerange` | eval lansweeper_id=coalesce(AssetID,id) \
-| eval fqdn=coalesce('assetBasicInfo.fqdn',FQDN) | eval hostname=lower(mvjoin(mvdedup(mvappend(AssetName, fqdn)),"~~")), ip=lower(IPAddress), mac_address=lower(Mac) \
-| rename _time as time, host as lansweeper_collected_by, site_name as Site, AssetTypename as AssetType, Statename as lansweeper_state, Userdomain as Domain, AssetGroup as GroupName, OScode as OSVersion, Username as lansweeper_user, version as AssetVersion, OS as lansweeper_os, fqdn as lansweeper_fqdn \
-| table time, lansweeper_collected_by, hostname, ip, mac_address, lansweeper_id, Site, AssetType, lansweeper_state, Domain, GroupName, OSVersion, BuildNumber, AssetVersion, lansweeper_user, lansweeper_os, Description, IPLocation, lansweeper_fqdn \
-| stats values(GroupName) as GroupName, first(*) as * by lansweeper_id \
-| table time, lansweeper_collected_by, hostname, ip, mac_address, lansweeper_id, Site, AssetType, lansweeper_state, Domain, GroupName, OSVersion, BuildNumber, AssetVersion, lansweeper_user, lansweeper_os, Description, IPLocation, lansweeper_fqdn \
-| eval _key=lansweeper_id | outputlookup cs_lansweeper_inventory \
+search = `cs_lansweeper` `cs_lansweeper_timerange` \
+| eval hostname=lower(mvjoin(mvdedup(mvappend(AssetName, FQDN)),"~~")), ip=lower(IPAddress), mac_address=lower(Mac) \
+| eval antivirus = mvzip(antivirus_name, antivirus_enabled, "#") \
+| rename _time as time, host as lansweeper_collected_by, site_name as Site, AssetTypename as AssetType, Statename as lansweeper_state, Userdomain as Domain, AssetGroup as GroupName, OScode as OSVersion, Username as lansweeper_user, version as AssetVersion, OS as lansweeper_os, FQDN as lansweeper_fqdn, AssetID as lansweeper_id, Firstseen as FirstSeen, Lastseen as LastSeen \
+| table time, lansweeper_collected_by, hostname, ip, mac_address, lansweeper_id, Site, AssetType, lansweeper_state, Domain, GroupName, OSVersion, BuildNumber, AssetVersion, lansweeper_user, lansweeper_os, Description, IPLocation, lansweeper_fqdn, antivirus, AssetDomain, FirstSeen, LastSeen, AssetName, Serialnumber, Processor, Model, Manufacturer, OSRelease, OSname, SystemVersion, Memory, LsAgentVersion, LastLsAgent, LastChanged, DNSName \
+| stats values(GroupName) as GroupName, values(antivirus) as antivirus, values(Processor) as Processor, first(*) as * by lansweeper_id \
+| eval _key=lansweeper_id \
+| outputlookup cs_lansweeper_inventory \
 | `cs_device_inventory_out_to_temp_lookup`
 # Note - We are not appending previous lookup in case of Lansweeper as Lansweeper Add-on always fetch full asset list.
 

--- a/cyences_app_for_splunk/default/transforms.conf
+++ b/cyences_app_for_splunk/default/transforms.conf
@@ -26,7 +26,7 @@ fields_list = indextime, time, ip, hostname, mac_address, lansweeper_id, tenable
 [cs_lansweeper_inventory]
 external_type = kvstore
 collection = cs_lansweeper_inventory_collection
-fields_list = _key, time, ip, hostname, mac_address, lansweeper_id, AssetType, AssetVersion, BuildNumber, Description, Domain, GroupName, IPLocation, OSVersion, lansweeper_collected_by, lansweeper_fqdn, lansweeper_os, lansweeper_state, lansweeper_user
+fields_list = _key, time, lansweeper_collected_by, hostname, ip, mac_address, lansweeper_id, Site, AssetType, lansweeper_state, Domain, GroupName, OSVersion, BuildNumber, AssetVersion, lansweeper_user, lansweeper_os, Description, IPLocation, lansweeper_fqdn, antivirus, AssetDomain, FirstSeen, LastSeen, AssetName, Serialnumber, Processor, Model, Manufacturer, OSRelease, OSname, SystemVersion, Memory, LsAgentVersion, LastLsAgent, LastChanged, DNSName
 
 [cs_tenable_inventory]
 external_type = kvstore


### PR DESCRIPTION
* Show the antivirus field detail in lansweeper dashboard as per new data collection.
* Update lansweeper panel of asset intelligence dashboard and lansweeper dashboard (window, linux, mac panels  ) to show the antivirus details 
* Use cs_lansweeper_inventory lookup in the dashboards