### PR TITLE
Reduce False positive failure in the Spike in File Writes Alert

### DIFF
--- a/cyences_app_for_splunk/default/macros.conf
+++ b/cyences_app_for_splunk/default/macros.conf
@@ -279,7 +279,7 @@ definition = `cs_gsuite` sourcetype=gapps:report:login
 # ================================== #
 
 #Ransomware
-[cs_system_folder_internal_filter]
+[cs_spike_in_the_file_writes_internal_filter]
 definition = (Filesystem.file_path!="C:\\Program Files\\*" Filesystem.file_path!="C:\\Program Files (x86)\\*" Filesystem.file_path!="C:\\Windows\\Temp\\*" Filesystem.file_path!="C:\\ProgramData\\Tenable\\Nessus\\nessus\\plugins\\*")
 iseval = 0
 

--- a/cyences_app_for_splunk/default/macros.conf
+++ b/cyences_app_for_splunk/default/macros.conf
@@ -279,6 +279,10 @@ definition = `cs_gsuite` sourcetype=gapps:report:login
 # ================================== #
 
 #Ransomware
+[cs_system_folder_internal_filter]
+definition = (Filesystem.file_path!="C:\\Program Files\\*" Filesystem.file_path!="C:\\Program Files (x86)\\*" Filesystem.file_path!="C:\\Windows\\Temp\\*" Filesystem.file_path!="C:\\ProgramData\\Tenable\\Nessus\\nessus\\plugins\\*")
+iseval = 0
+
 [cs_system_processes_run_from_unexpected_locations_internal_filter]
 # fake windows processes - internal use macro
 definition = search *

--- a/cyences_app_for_splunk/default/savedsearches.conf
+++ b/cyences_app_for_splunk/default/savedsearches.conf
@@ -74,7 +74,7 @@ display.page.search.mode = fast
 display.visualizations.show = 0
 request.ui_dispatch_app = cyences_app_for_splunk
 request.ui_dispatch_view = search
-search = | tstats `cs_summariesonly_endpoint` count FROM datamodel=Endpoint.Filesystem where Filesystem.action=created `cs_system_folder_internal_filter` by _time span=1h, Filesystem.dest | `drop_dm_object_name(Filesystem)` \
+search = | tstats `cs_summariesonly_endpoint` count FROM datamodel=Endpoint.Filesystem where Filesystem.action=created `cs_spike_in_the_file_writes_internal_filter` by _time span=1h, Filesystem.dest | `drop_dm_object_name(Filesystem)` \
 | eventstats max(_time) as maxtime \
 | stats avg(eval(if(_time<relative_time(maxtime, "-1d@d"), count,null))) as avg stdev(eval(if(_time<relative_time(maxtime, "-1d@d"), count, null))) as stdev by "dest" \
 | eval upperBound=(avg+stdev*4) \
@@ -105,7 +105,7 @@ display.page.search.tab = statistics
 display.page.search.mode = fast
 request.ui_dispatch_app = cyences_app_for_splunk
 request.ui_dispatch_view = search
-search = | tstats `cs_summariesonly_endpoint` count min(_time) as firstTime max(_time) as lastTime FROM datamodel=Endpoint.Filesystem where Filesystem.action=created `cs_system_folder_internal_filter` by Filesystem.dest, Filesystem.file_path | `drop_dm_object_name(Filesystem)` \
+search = | tstats `cs_summariesonly_endpoint` count min(_time) as firstTime max(_time) as lastTime FROM datamodel=Endpoint.Filesystem where Filesystem.action=created `cs_spike_in_the_file_writes_internal_filter` by Filesystem.dest, Filesystem.file_path | `drop_dm_object_name(Filesystem)` \
 | rex field=file_path "(?<file_location>.*)[\\\\|\\/]" \
 | stats sum(count) as count, min(firstTime) as firstTime max(lastTime) as lastTime by dest, file_location \
 | sort - count | eval file_location=file_location." (".count.")" \

--- a/cyences_app_for_splunk/default/savedsearches.conf
+++ b/cyences_app_for_splunk/default/savedsearches.conf
@@ -74,7 +74,7 @@ display.page.search.mode = fast
 display.visualizations.show = 0
 request.ui_dispatch_app = cyences_app_for_splunk
 request.ui_dispatch_view = search
-search = | tstats `cs_summariesonly_endpoint` count FROM datamodel=Endpoint.Filesystem where Filesystem.action=created Filesystem.file_path!="C:\\Program Files\\*" Filesystem.file_path!="C:\\Program Files (x86)\\*" Filesystem.file_path!="C:\\Windows\\Temp\\*" Filesystem.file_path!="C:\\ProgramData\\Tenable\\Nessus\\nessus\\plugins\\*" by _time span=1h, Filesystem.dest | `drop_dm_object_name(Filesystem)` \
+search = | tstats `cs_summariesonly_endpoint` count FROM datamodel=Endpoint.Filesystem where Filesystem.action=created `cs_system_folder_internal_filter` by _time span=1h, Filesystem.dest | `drop_dm_object_name(Filesystem)` \
 | eventstats max(_time) as maxtime \
 | stats avg(eval(if(_time<relative_time(maxtime, "-1d@d"), count,null))) as avg stdev(eval(if(_time<relative_time(maxtime, "-1d@d"), count, null))) as stdev by "dest" \
 | eval upperBound=(avg+stdev*4) \
@@ -105,7 +105,7 @@ display.page.search.tab = statistics
 display.page.search.mode = fast
 request.ui_dispatch_app = cyences_app_for_splunk
 request.ui_dispatch_view = search
-search = | tstats `cs_summariesonly_endpoint` count min(_time) as firstTime max(_time) as lastTime FROM datamodel=Endpoint.Filesystem where Filesystem.action=created Filesystem.file_path!="C:\\Program Files\\*" Filesystem.file_path!="C:\\Program Files (x86)\\*" Filesystem.file_path!="C:\\Windows\\Temp\\*" Filesystem.file_path!="C:\\ProgramData\\Tenable\\Nessus\\nessus\\plugins\\*" by Filesystem.dest, Filesystem.file_path | `drop_dm_object_name(Filesystem)` \
+search = | tstats `cs_summariesonly_endpoint` count min(_time) as firstTime max(_time) as lastTime FROM datamodel=Endpoint.Filesystem where Filesystem.action=created `cs_system_folder_internal_filter` by Filesystem.dest, Filesystem.file_path | `drop_dm_object_name(Filesystem)` \
 | rex field=file_path "(?<file_location>.*)[\\\\|\\/]" \
 | stats sum(count) as count, min(firstTime) as firstTime max(lastTime) as lastTime by dest, file_location \
 | sort - count | eval file_location=file_location." (".count.")" \

--- a/cyences_app_for_splunk/default/savedsearches.conf
+++ b/cyences_app_for_splunk/default/savedsearches.conf
@@ -74,7 +74,7 @@ display.page.search.mode = fast
 display.visualizations.show = 0
 request.ui_dispatch_app = cyences_app_for_splunk
 request.ui_dispatch_view = search
-search = | tstats `cs_summariesonly_endpoint` count FROM datamodel=Endpoint.Filesystem where Filesystem.action=created by _time span=1h, Filesystem.dest | `drop_dm_object_name(Filesystem)` \
+search = | tstats `cs_summariesonly_endpoint` count FROM datamodel=Endpoint.Filesystem where Filesystem.action=created Filesystem.file_path!="C:\\Program Files\\*" Filesystem.file_path!="C:\\Program Files (x86)\\*" Filesystem.file_path!="C:\\Windows\\Temp\\*" Filesystem.file_path!="C:\\ProgramData\\Tenable\\Nessus\\nessus\\plugins\\*" by _time span=1h, Filesystem.dest | `drop_dm_object_name(Filesystem)` \
 | eventstats max(_time) as maxtime \
 | stats avg(eval(if(_time<relative_time(maxtime, "-1d@d"), count,null))) as avg stdev(eval(if(_time<relative_time(maxtime, "-1d@d"), count, null))) as stdev by "dest" \
 | eval upperBound=(avg+stdev*4) \
@@ -105,7 +105,7 @@ display.page.search.tab = statistics
 display.page.search.mode = fast
 request.ui_dispatch_app = cyences_app_for_splunk
 request.ui_dispatch_view = search
-search = | tstats `cs_summariesonly_endpoint` count min(_time) as firstTime max(_time) as lastTime FROM datamodel=Endpoint.Filesystem where Filesystem.action=created by Filesystem.dest, Filesystem.file_path | `drop_dm_object_name(Filesystem)` \
+search = | tstats `cs_summariesonly_endpoint` count min(_time) as firstTime max(_time) as lastTime FROM datamodel=Endpoint.Filesystem where Filesystem.action=created Filesystem.file_path!="C:\\Program Files\\*" Filesystem.file_path!="C:\\Program Files (x86)\\*" Filesystem.file_path!="C:\\Windows\\Temp\\*" Filesystem.file_path!="C:\\ProgramData\\Tenable\\Nessus\\nessus\\plugins\\*" by Filesystem.dest, Filesystem.file_path | `drop_dm_object_name(Filesystem)` \
 | rex field=file_path "(?<file_location>.*)[\\\\|\\/]" \
 | stats sum(count) as count, min(firstTime) as firstTime max(lastTime) as lastTime by dest, file_location \
 | sort - count | eval file_location=file_location." (".count.")" \
@@ -142,7 +142,7 @@ display.page.search.tab = statistics
 display.page.search.mode = fast
 request.ui_dispatch_app = cyences_app_for_splunk
 request.ui_dispatch_view = search
-search = | tstats `cs_summariesonly_endpoint` count min(_time) as firstTime max(_time) as lastTime FROM datamodel=Endpoint.Processes where Processes.process_path !="C:\\Windows\\System32*" Processes.process_path !="C:\\Windows\\SysWOW64*" by Processes.user Processes.dest Processes.process_name Processes.process_id Processes.process_path Processes.parent_process_name Processes.process_hash \
+search = | tstats `cs_summariesonly_endpoint` count min(_time) as firstTime max(_time) as lastTime FROM datamodel=Endpoint.Processes where Processes.process_path !="C:\\Windows\\System32*" Processes.process_path !="C:\\Windows\\SysWOW64*" by Processes.user Processes.dest Processes.process_name Processes.process_id Processes.process_path Processes.parent_process_name Processes.parent_process_path Processes.process_hash \
 | `drop_dm_object_name("Processes")` \
 |  `cs_system_processes_run_from_unexpected_locations_internal_filter` \
 | lookup cs_fake_windows_processes_filter process_name, process_hash OUTPUT need_to_filtered | search NOT need_to_filtered=1 \


### PR DESCRIPTION
Changes:
* Ignore below file paths in the alerts `Ransomware - Calculate UpperBound for Spike in File Writes` and `Ransomware - Spike in File Writes` to reduce the false positives.
  * `C:\Program Files\*`
  * `C:\Program Files (x86)\*`
  * `C:\Windows\Temp\*`
  * `C:\ProgramData\Tenable\Nessus\nessus\plugins\*`
* Added `parent_process_path` field in the group by field in the `Ransomware - Endpoint Compromise - Fake Windows Processes` alert 