### PR TITLE
Fix token name to populate the "PowerShell Script Execution Error" panel

### DIFF
--- a/cyences_app_for_splunk/default/data/ui/views/cs_o365_defender_atp_audit.xml
+++ b/cyences_app_for_splunk/default/data/ui/views/cs_o365_defender_atp_audit.xml
@@ -49,7 +49,7 @@
           <latest>now</latest>
         </default>
       </input>
-      <input type="text" token="tkn_host_error_messages">
+      <input type="text" token="tkn_host_error_message">
         <label>Host</label>
         <default>*</default>
         <prefix>*</prefix>


### PR DESCRIPTION
Fix token name to populate the "PowerShell Script Execution Error" panel