### PR TITLE
Ignore Temp folder  to reduce false positive failures for Spike in File write alerts 

### DIFF
--- a/cyences_app_for_splunk/default/macros.conf
+++ b/cyences_app_for_splunk/default/macros.conf
@@ -280,7 +280,7 @@ definition = `cs_gsuite` sourcetype=gapps:report:login
 
 #Ransomware
 [cs_spike_in_the_file_writes_internal_filter]
-definition = (Filesystem.file_path!="C:\\Program Files\\*" Filesystem.file_path!="C:\\Program Files (x86)\\*" Filesystem.file_path!="C:\\Windows\\Temp\\*" Filesystem.file_path!="C:\\ProgramData\\Tenable\\Nessus\\nessus\\plugins\\*")
+definition = (Filesystem.file_path!="C:\\Program Files\\*" Filesystem.file_path!="C:\\Program Files (x86)\\*" Filesystem.file_path!="C:\\Windows\\Temp\\*" Filesystem.file_path!="C:\\ProgramData\\Tenable\\Nessus\\nessus\\plugins\\*" Filesystem.file_path!="C:\\Windows\\ServiceProfiles\\LocalService\\AppData\\Local\\Temp\\*" Filesystem.file_path!="C:\\Users\\*\\AppData\\Local\\Temp\\*")
 iseval = 0
 
 [cs_system_processes_run_from_unexpected_locations_internal_filter]

--- a/cyences_app_for_splunk/default/macros.conf
+++ b/cyences_app_for_splunk/default/macros.conf
@@ -293,7 +293,7 @@ definition = search NOT file_path IN ("C:\\ProgramData\\Microsoft\\Windows Defen
 iseval = 0
 
 [cs_ransomware_min_file_writes]
-definition = 20
+definition = 3000
 
 [cs_ransomware_min_file_extension_count]
 definition = 10

--- a/cyences_app_for_splunk/default/savedsearches.conf
+++ b/cyences_app_for_splunk/default/savedsearches.conf
@@ -77,7 +77,7 @@ request.ui_dispatch_view = search
 search = | tstats `cs_summariesonly_endpoint` count FROM datamodel=Endpoint.Filesystem where Filesystem.action=created `cs_spike_in_the_file_writes_internal_filter` by _time span=1h, Filesystem.dest | `drop_dm_object_name(Filesystem)` \
 | eventstats max(_time) as maxtime \
 | stats avg(eval(if(_time<relative_time(maxtime, "-1d@d"), count,null))) as avg stdev(eval(if(_time<relative_time(maxtime, "-1d@d"), count, null))) as stdev by "dest" \
-| eval upperBound=(avg+stdev*4) \
+| eval upperBound=(avg+stdev*5) \
 | outputlookup cs_ransomware_file_writes_upperbound.csv
 
 

--- a/cyences_app_for_splunk/default/savedsearches.conf
+++ b/cyences_app_for_splunk/default/savedsearches.conf
@@ -77,7 +77,7 @@ request.ui_dispatch_view = search
 search = | tstats `cs_summariesonly_endpoint` count FROM datamodel=Endpoint.Filesystem where Filesystem.action=created `cs_spike_in_the_file_writes_internal_filter` by _time span=1h, Filesystem.dest | `drop_dm_object_name(Filesystem)` \
 | eventstats max(_time) as maxtime \
 | stats avg(eval(if(_time<relative_time(maxtime, "-1d@d"), count,null))) as avg stdev(eval(if(_time<relative_time(maxtime, "-1d@d"), count, null))) as stdev by "dest" \
-| eval upperBound=(avg+stdev*5) \
+| eval upperBound=(avg+stdev*4) \
 | outputlookup cs_ransomware_file_writes_upperbound.csv
 
 


### PR DESCRIPTION
* Ignore Temp folder  to reduce false positive failures for Spike in File write alerts 
* Update min_file_write limit to 3000