### PR TITLE
CY-350: Add private ip details in the vpn dashboad

### DIFF
--- a/cyences_app_for_splunk/default/data/ui/views/cs_vpn_reports.xml
+++ b/cyences_app_for_splunk/default/data/ui/views/cs_vpn_reports.xml
@@ -197,9 +197,40 @@
         </search>
         <option name="count">5</option>
         <option name="refresh.display">progressbar</option>
+        <option name="drilldown">row</option>
         <option name="rowNumbers">true</option>
         <drilldown>
-          <link target="_blank">search?q=%60rw_vpn_indexes%60%20TERM($row.User$)%20user=$row.User$%20TERM($row.SourceIP$)%20src_ip=$row.SourceIP$&amp;earliest=$time.earliest$&amp;latest=$time.latest$</link>
+          <link target="_blank">search?q=%60cs_vpn_indexes%60%20TERM($row.User$)%20user=$row.User$%20TERM($row.SourceIP$)%20src_ip=$row.SourceIP$&amp;earliest=$time.earliest$&amp;latest=$time.latest$</link>
+        </drilldown>
+      </table>
+    </panel>
+  </row>
+  <row>
+    <panel>
+      <title>Successful Session</title>
+      <table>
+        <search>
+          <query>`cs_vpn_indexes` dest_category="vpn_auth" action="success" $User$
+| stats values(src) as src_ip, values(private_ip) as private_ip by action, user, _time 
+| eval private_ip = if(private_ip="0.0.0.0", null(), private_ip) 
+| search user="*" 
+| iplocation src_ip 
+| eval Country = if(isnull(Country) OR Country="", "Unknown", Country) 
+| eval City = if(isnull(City) OR City="", "Unknown", City) 
+| search $Country$ $City$ 
+| `cs_vpn_dashboard_filter` 
+| fields _time user action private_ip src_ip City Country 
+| rename user as User, action as Status, src_ip as "SourceIP", private_ip as "PrivateIP" 
+| sort - _time</query>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
+        </search>
+        <option name="count">5</option>
+        <option name="refresh.display">progressbar</option>
+        <option name="drilldown">row</option>
+        <option name="rowNumbers">true</option>
+        <drilldown>
+          <link target="_blank">search?q=%60cs_vpn_indexes%60%20TERM($row.User$)%20user=$row.User$%20TERM($row.SourceIP$)%20src_ip=$row.SourceIP$&amp;earliest=$time.earliest$&amp;latest=$time.latest$</link>
         </drilldown>
       </table>
     </panel>

--- a/cyences_app_for_splunk/default/data/ui/views/cs_vpn_reports.xml
+++ b/cyences_app_for_splunk/default/data/ui/views/cs_vpn_reports.xml
@@ -211,16 +211,15 @@
       <table>
         <search>
           <query>`cs_vpn_indexes` dest_category="vpn_auth" action="success" $User$
-| stats values(src) as src_ip, values(private_ip) as private_ip by action, user, _time 
+| fields _time user action private_ip src City Country
 | eval private_ip = if(private_ip="0.0.0.0", null(), private_ip) 
-| search user="*" 
-| iplocation src_ip 
+| iplocation src 
 | eval Country = if(isnull(Country) OR Country="", "Unknown", Country) 
 | eval City = if(isnull(City) OR City="", "Unknown", City) 
 | search $Country$ $City$ 
 | `cs_vpn_dashboard_filter` 
-| fields _time user action private_ip src_ip City Country 
-| rename user as User, action as Status, src_ip as "SourceIP", private_ip as "PrivateIP" 
+| table _time user action private_ip src City Country 
+| rename user as User, action as Status, src as "SourceIP", private_ip as "PrivateIP" 
 | sort - _time</query>
           <earliest>$time.earliest$</earliest>
           <latest>$time.latest$</latest>

--- a/cyences_app_for_splunk/default/eventtypes.conf
+++ b/cyences_app_for_splunk/default/eventtypes.conf
@@ -11,7 +11,7 @@ search = (sourcetype=pan_system OR sourcetype=pan:system) (event_id="globalprote
 
 # New
 [cs_palo_gp_new_login]
-search = sourcetype="pan:globalprotect" log_subtype="login" (event_id="portal-auth" OR event_id="gateway-auth" OR event_id="gateway-register")
+search = sourcetype="pan:globalprotect" (log_subtype="login" (event_id="portal-auth" OR event_id="gateway-auth")) OR (log_subtype="connected" event_id="gateway-connected")
 
 [cs_palo_gp_new_connected]
 search = sourcetype="pan:globalprotect" log_subtype="connected" event_id="gateway-connected"

--- a/cyences_app_for_splunk/default/props.conf
+++ b/cyences_app_for_splunk/default/props.conf
@@ -66,14 +66,14 @@ EVAL-action = case(isnotnull(action),action,(Operation == "UserLoginFailed"),"fa
 [pan:globalprotect]
 EVAL-src = coalesce(src, src_ip)
 EVAL-action = coalesce(action, status)
-EVAL-dest_category = if(((log_subtype="login") AND (((event_id="portal-auth" OR event_id="gateway-auth") AND (action="failure" OR status="failure")) OR (event_id="gateway-register" AND (action="success" OR status="success")))), "vpn_auth", dest_category)
+EVAL-dest_category = if((log_subtype="login" AND (event_id="portal-auth" OR event_id="gateway-auth") AND (action="failure" OR status="failure")) OR (log_subtype="connected" AND event_id="gateway-connected" AND (action="success" OR status="success")), "vpn_auth", dest_category)
 
 # Logic for login success on Palo Alto App (New Version of Global Protect)
 # Success - log_subtype="connected"
 # Failure - result="failure"
 
 # Logic Here (New Version of Global Protect)
-# Success - (event_id="gateway-register") action="success"
+# Success - (event_id="gateway-connected") action="success"
 # Failure - (event_id="portal-auth" OR event_id="gateway-auth") action="failure"
 
 


### PR DESCRIPTION
* Add Successful Session panel to show private ip detail
* Fix the drilldown query in the Login Details panel

**Note**: The private ip field is not present in the sourcetype=pan:system events (Legacy Palo Alto events)