### PR TITLE
CY-392: Update alert and dashboard to use the new o365:service:healthIssue sourcetype

### DIFF
--- a/cyences_app_for_splunk/default/data/ui/views/cs_o365_reports.xml
+++ b/cyences_app_for_splunk/default/data/ui/views/cs_o365_reports.xml
@@ -135,23 +135,24 @@
       <!-- Service Status Reference - https://docs.microsoft.com/en-us/dotnet/api/microsoft.exchange.servicestatus.tenantcommunications.data.servicestatus?view=o365-service-communications -->
       <table id="my_table_with_default_sort">
         <search>
-          <query>`cs_o365` sourcetype="o365:service:status" $tkn_host$ source="*CurrentStatus"
-| stats latest(Status) as Status latest(_time) as _time by WorkloadDisplayName host 
+          <query>`cs_o365` (sourcetype="o365:service:healthIssue" OR (sourcetype="o365:service:status" source="*CurrentStatus")) $tkn_host$ 
+| eval Status = coalesce(status, Status), Service = coalesce(service, WorkloadDisplayName) 
+| stats latest(Status) as Status latest(_time) as _time by Service host 
 | rename _time as "LastUpdatedTime" 
 | convert ctime(LastUpdatedTime) as LastUpdatedTime 
-| table LastUpdatedTime host Work* Status 
+| table LastUpdatedTime host Service Status 
 | sort host Status 
-| eval Status_temp=Status
-| eval Status=case(Status_temp=="ServiceInterruption",0,Status_temp=="ServiceDegradation",1,Status_temp=="RestoringService",2,Status_temp=="ExtendedRecovery",3,Status_temp=="Investigating",4,Status_temp=="ServiceRestored",5,Status_temp=="FalsePositive",6,Status_temp=="PostIncidentReviewPublished",7,Status_temp=="InformationUnavailable",8,Status_temp=="ServiceOperational",99) 
-| fieldformat  Status=Status_temp</query>
+| eval Status_temp=lower(Status) 
+| eval Status=case(Status_temp=="serviceinterruption",0,Status_temp=="servicedegradation",1,Status_temp=="restoringservice",2,Status_temp=="extendedrecovery",3,Status_temp=="investigating",4,Status_temp=="servicerestored",5,Status_temp=="falsepositive",6,Status_temp=="postincidentreviewpublished",7,Status_temp=="informationunavailable",8,Status_temp=="serviceoperational",99) 
+| fieldformat Status=Status_temp</query>
           <earliest>$timeRange.earliest$</earliest>
           <latest>$timeRange.latest$</latest>
         </search>
-        <fields>LastUpdatedTime,host,WorkloadDisplayName, Status</fields>
+        <fields>LastUpdatedTime,host,Service,Status</fields>
         <option name="drilldown">none</option>
         <option name="refresh.display">progressbar</option>
         <format type="color" field="Status">
-          <colorPalette type="map">{"ServiceOperational":#499547,"ServiceDegradation":#DC4E41,"RestoringService":#F8BE34,"FalsePositive":#006D9C,"Investigating":#F1813F,"ServiceRestored":#4FA484,"InformationAvailable":#E86DD3,"PIRPublished":#E86DD3}</colorPalette>
+          <colorPalette type="map">{"serviceoperational":#499547,"servicedegradation":#DC4E41,"restoringservice":#F8BE34,"falsepositive":#006D9C,"investigating":#F1813F,"servicerestored":#4FA484,"informationavailable":#E86DD3,"pirpublished":#E86DD3}</colorPalette>
         </format>
       </table>
     </panel>

--- a/cyences_app_for_splunk/default/data/ui/views/cs_overview.xml
+++ b/cyences_app_for_splunk/default/data/ui/views/cs_overview.xml
@@ -210,8 +210,9 @@
           <query>| `cs_filter_savedsearches("O365|Email")` 
 | rename "Notable Events" as Count 
 | append 
-    [| search `cs_o365` sourcetype="o365:service:status" source="*current*"  earliest=$timeRange.earliest$ latest=$timeRange.latest$
-    | stats latest(Status) as Status latest(_time) as _time by WorkloadDisplayName host 
+    [| search `cs_o365` (sourcetype="o365:service:healthIssue" OR (sourcetype="o365:service:status" source="*CurrentStatus"))  earliest=$timeRange.earliest$ latest=$timeRange.latest$
+    | eval Status = coalesce(status, Status), Service = coalesce(service, WorkloadDisplayName) 
+    | stats latest(Status) as Status latest(_time) as _time by Service host 
     | search Status IN ("ExtendedRecovery","InformationUnavailable","Investigating*","RestoringService","ServiceDegradation","ServiceInterruption") 
     | stats count as Count
     | search [| search `cs_o365` earliest=$timeRange.earliest$ latest=$timeRange.latest$ | head 1 | stats count | eval search=if(count&gt;0, "", "sourcetype=DONOTRETURNANYRESULTS") | fields search | return $search]

--- a/cyences_app_for_splunk/default/savedsearches.conf
+++ b/cyences_app_for_splunk/default/savedsearches.conf
@@ -1345,11 +1345,12 @@ display.page.search.tab = statistics
 display.page.search.mode = fast
 request.ui_dispatch_app = cyences_app_for_splunk
 request.ui_dispatch_view = search
-search = `cs_o365` _index_earliest=-61m@m _index_latest=-1m@m sourcetype="o365:service:status" source="*CurrentStatus" \
-| stats latest(Status) as Status latest(_time) as _time by WorkloadDisplayName host \
+search = `cs_o365` _index_earliest=-61m@m _index_latest=-1m@m (sourcetype="o365:service:healthIssue" OR (sourcetype="o365:service:status" source="*CurrentStatus")) \
+| eval Status = coalesce(status, Status), Service = coalesce(service, WorkloadDisplayName) \
+| stats latest(Status) as Status latest(_time) as _time by Service host \
 | search Status IN ("ExtendedRecovery","InformationUnavailable","Investigating*","RestoringService","ServiceDegradation","ServiceInterruption") \
 | `cs_human_readable_time_format(_time, LastUpdatedTime)` \
-| table LastUpdatedTime host Work* Status \
+| table LastUpdatedTime host Service Status \
 | sort host Status | `cs_o365_service_not_operational_filter`
 action.summary_index = 1
 action.summary_index._name = cyences


### PR DESCRIPTION
* Update alert and dashboard to use the new o365:service:healthIssue sourcetype (The "o365:service:status" sourcetype is Retired )