### PR TITLE
Fix the alert_name field issue, management activity duplicate event issue

### DIFF
--- a/cyences_app_for_splunk/default/macros.conf
+++ b/cyences_app_for_splunk/default/macros.conf
@@ -300,7 +300,8 @@ definition = 10
 
 # O365
 [cs_o365_managementactivity_change_out]
-definition = spath path=Target{} output=Target \
+definition =  dedup Id \
+| spath path=Target{} output=Target \
 | rex mode=sed "s/\\\r|\\\n//g" field=Target \
 | rex max_match=0 field=Target "\"ID\":\s*(?<Target_DisplayName>.*),\s*\"Type\":\s*1\}" \
 | spath path=ExtendedProperties{} output=ExtendedProperties \

--- a/cyences_app_for_splunk/default/savedsearches.conf
+++ b/cyences_app_for_splunk/default/savedsearches.conf
@@ -1436,18 +1436,18 @@ alert.suppress = 0
 counttype = number of events
 quantity = 0
 relation = greater than
-cron_schedule = 9,39 * * * *
+cron_schedule = 29 * * * *
 description = This alert will show the change/update in AuthorizationPolicy. \
 \
 Data Collection - Office 365 management activity data (Splunk Add-on for Office 365). 
-dispatch.earliest_time = -2h@h
+dispatch.earliest_time = -4h@h
 dispatch.latest_time = +2h@h
 display.general.type = statistics
 display.page.search.tab = statistics
 display.page.search.mode = fast
 request.ui_dispatch_app = cyences_app_for_splunk
 request.ui_dispatch_view = search
-search = `cs_o365_managementactivity_change("AuthorizationPolicy")` _index_earliest=-31m@m _index_latest=-1m@m \
+search = `cs_o365_managementactivity_change("AuthorizationPolicy")` _index_earliest=-61m@m _index_latest=-1m@m \
 | `cs_o365_managementactivity_change_out` \
 | `cs_o365_authorizationpolicy_change_internal_filter` \
 | `cs_o365_authorizationpolicy_change_filter`  \
@@ -1455,7 +1455,7 @@ search = `cs_o365_managementactivity_change("AuthorizationPolicy")` _index_earli
 action.summary_index = 1
 action.summary_index._name = cyences
 action.summary_index.category = O365
-action.summary_index.alert_name = O365 - AuthorizationPolicy Change/Update
+action.summary_index.alert_name = O365 - Azure Active Directory - AuthorizationPolicy Change/Update
 
 
 [O365 - Azure Active Directory - Policy Change/Update]
@@ -1467,18 +1467,18 @@ alert.suppress = 0
 counttype = number of events
 quantity = 0
 relation = greater than
-cron_schedule = 9,39 * * * *
+cron_schedule = 59 * * * *
 description = This alert will show the change/update in Policy. \
 \
 Data Collection - Office 365 management activity data (Splunk Add-on for Office 365). 
-dispatch.earliest_time = -2h@h
+dispatch.earliest_time = -4h@h
 dispatch.latest_time = +2h@h
 display.general.type = statistics
 display.page.search.tab = statistics
 display.page.search.mode = fast
 request.ui_dispatch_app = cyences_app_for_splunk
 request.ui_dispatch_view = search
-search = `cs_o365_managementactivity_change("Policy")` _index_earliest=-31m@m _index_latest=-1m@m \
+search = `cs_o365_managementactivity_change("Policy")` _index_earliest=-61m@m _index_latest=-1m@m \
 | `cs_o365_managementactivity_change_out` \
 | `cs_o365_policy_change_internal_filter` \
 | `cs_o365_policy_change_filter`  \
@@ -1486,7 +1486,7 @@ search = `cs_o365_managementactivity_change("Policy")` _index_earliest=-31m@m _i
 action.summary_index = 1
 action.summary_index._name = cyences
 action.summary_index.category = O365
-action.summary_index.alert_name = O365 - Policy Change/Update
+action.summary_index.alert_name = O365 - Azure Active Directory - Policy Change/Update
 
 
 [O365 - Azure Active Directory - Role Change/Update]
@@ -1498,18 +1498,18 @@ alert.suppress = 0
 counttype = number of events
 quantity = 0
 relation = greater than
-cron_schedule = 9,39 * * * *
+cron_schedule = 29 * * * *
 description = This alert will show the change/update in Role. \
 \
 Data Collection - Office 365 management activity data (Splunk Add-on for Office 365). 
-dispatch.earliest_time = -2h@h
+dispatch.earliest_time = -4h@h
 dispatch.latest_time = +2h@h
 display.general.type = statistics
 display.page.search.tab = statistics
 display.page.search.mode = fast
 request.ui_dispatch_app = cyences_app_for_splunk
 request.ui_dispatch_view = search
-search = `cs_o365_managementactivity_change("Role")` _index_earliest=-31m@m _index_latest=-1m@m \
+search = `cs_o365_managementactivity_change("Role")` _index_earliest=-61m@m _index_latest=-1m@m \
 | `cs_o365_managementactivity_change_out` \
 | `cs_o365_role_change_internal_filter` \
 | `cs_o365_role_change_filter`   \
@@ -1517,7 +1517,7 @@ search = `cs_o365_managementactivity_change("Role")` _index_earliest=-31m@m _ind
 action.summary_index = 1
 action.summary_index._name = cyences
 action.summary_index.category = O365
-action.summary_index.alert_name = O365 - Role Change/Update
+action.summary_index.alert_name = O365 - Azure Active Directory - Role Change/Update
 
 
 [O365 - Azure Active Directory - Group Change/Update]
@@ -1529,18 +1529,18 @@ alert.suppress = 0
 counttype = number of events
 quantity = 0
 relation = greater than
-cron_schedule = 9,39 * * * *
+cron_schedule = 59 * * * *
 description = This alert will show the change/update in Group. \
 \
 Data Collection - Office 365 management activity data (Splunk Add-on for Office 365). 
-dispatch.earliest_time = -2h@h
+dispatch.earliest_time = -4h@h
 dispatch.latest_time = +2h@h
 display.general.type = statistics
 display.page.search.tab = statistics
 display.page.search.mode = fast
 request.ui_dispatch_app = cyences_app_for_splunk
 request.ui_dispatch_view = search
-search = `cs_o365_managementactivity_change("Group")` _index_earliest=-31m@m _index_latest=-1m@m \
+search = `cs_o365_managementactivity_change("Group")` _index_earliest=-61m@m _index_latest=-1m@m \
 | `cs_o365_managementactivity_change_out` \
 | `cs_o365_group_change_internal_filter` \
 | `cs_o365_group_change_filter`  \
@@ -1548,7 +1548,7 @@ search = `cs_o365_managementactivity_change("Group")` _index_earliest=-31m@m _in
 action.summary_index = 1
 action.summary_index._name = cyences
 action.summary_index.category = O365
-action.summary_index.alert_name = O365 - Group Change/Update
+action.summary_index.alert_name = O365 - Azure Active Directory - Group Change/Update
 
 
 [O365 - Azure Active Directory - GroupMembership Change/Update]
@@ -1560,18 +1560,18 @@ alert.suppress = 0
 counttype = number of events
 quantity = 0
 relation = greater than
-cron_schedule = 9,39 * * * *
+cron_schedule = 29 * * * *
 description = This alert will show the change/update in Group members. \
 \
 Data Collection - Office 365 management activity data (Splunk Add-on for Office 365). 
-dispatch.earliest_time = -2h@h
+dispatch.earliest_time = -4h@h
 dispatch.latest_time = +2h@h
 display.general.type = statistics
 display.page.search.tab = statistics
 display.page.search.mode = fast
 request.ui_dispatch_app = cyences_app_for_splunk
 request.ui_dispatch_view = search
-search = `cs_o365_managementactivity_change("GroupMembership")` _index_earliest=-31m@m _index_latest=-1m@m \
+search = `cs_o365_managementactivity_change("GroupMembership")` _index_earliest=-61m@m _index_latest=-1m@m \
 | `cs_o365_managementactivity_change_out` \
 | `cs_o365_group_membership_change_internal_filter` \
 | `cs_o365_group_membership_change_filter`  \
@@ -1579,7 +1579,7 @@ search = `cs_o365_managementactivity_change("GroupMembership")` _index_earliest=
 action.summary_index = 1
 action.summary_index._name = cyences
 action.summary_index.category = O365
-action.summary_index.alert_name = O365 - GroupMembership Change/Update
+action.summary_index.alert_name = O365 - Azure Active Directory - GroupMembership Change/Update
 
 
 [O365 - Azure Active Directory - User Change/Update]
@@ -1591,18 +1591,18 @@ alert.suppress = 0
 counttype = number of events
 quantity = 0
 relation = greater than
-cron_schedule = 9,39 * * * *
+cron_schedule = 59 * * * *
 description = This alert will show the change/update in User. \
 \
 Data Collection - Office 365 management activity data (Splunk Add-on for Office 365). 
-dispatch.earliest_time = -2h@h
+dispatch.earliest_time = -4h@h
 dispatch.latest_time = +2h@h
 display.general.type = statistics
 display.page.search.tab = statistics
 display.page.search.mode = fast
 request.ui_dispatch_app = cyences_app_for_splunk
 request.ui_dispatch_view = search
-search = `cs_o365_managementactivity_change("User")` _index_earliest=-31m@m _index_latest=-1m@m \
+search = `cs_o365_managementactivity_change("User")` _index_earliest=-61m@m _index_latest=-1m@m \
 | `cs_o365_managementactivity_change_out` \
 | `cs_o365_user_change_internal_filter` \
 | `cs_o365_user_change_filter`  \
@@ -1610,7 +1610,7 @@ search = `cs_o365_managementactivity_change("User")` _index_earliest=-31m@m _ind
 action.summary_index = 1
 action.summary_index._name = cyences
 action.summary_index.category = O365
-action.summary_index.alert_name = O365 - User Change/Update
+action.summary_index.alert_name = O365 - Azure Active Directory - User Change/Update
 
 
 [O365 - Azure Active Directory - ServicePrincipal Change/Update]
@@ -1622,18 +1622,18 @@ alert.suppress = 0
 counttype = number of events
 quantity = 0
 relation = greater than
-cron_schedule = 9,39 * * * *
+cron_schedule = 29 * * * *
 description = This alert will show the change/update in ServicePrincipal. \
 \
 Data Collection - Office 365 management activity data (Splunk Add-on for Office 365). 
-dispatch.earliest_time = -2h@h
+dispatch.earliest_time = -4h@h
 dispatch.latest_time = +2h@h
 display.general.type = statistics
 display.page.search.tab = statistics
 display.page.search.mode = fast
 request.ui_dispatch_app = cyences_app_for_splunk
 request.ui_dispatch_view = search
-search = `cs_o365_managementactivity_change("ServicePrincipal")` _index_earliest=-31m@m _index_latest=-1m@m \
+search = `cs_o365_managementactivity_change("ServicePrincipal")` _index_earliest=-61m@m _index_latest=-1m@m \
 | `cs_o365_managementactivity_change_out` \
 | `cs_o365_serviceprincipal_change_internal_filter` \
 | `cs_o365_serviceprincipal_change_filter`  \
@@ -1641,7 +1641,7 @@ search = `cs_o365_managementactivity_change("ServicePrincipal")` _index_earliest
 action.summary_index = 1
 action.summary_index._name = cyences
 action.summary_index.category = O365
-action.summary_index.alert_name = O365 - ServicePrincipal Change/Update
+action.summary_index.alert_name = O365 - Azure Active Directory - ServicePrincipal Change/Update
 
 
 [O365 - Azure Active Directory - Application Change/Update]
@@ -1653,18 +1653,18 @@ alert.suppress = 0
 counttype = number of events
 quantity = 0
 relation = greater than
-cron_schedule = 9,39 * * * *
+cron_schedule = 59 * * * *
 description = This alert will show the change/update in Application. \
 \
 Data Collection - Office 365 management activity data (Splunk Add-on for Office 365). 
-dispatch.earliest_time = -2h@h
+dispatch.earliest_time = -4h@h
 dispatch.latest_time = +2h@h
 display.general.type = statistics
 display.page.search.tab = statistics
 display.page.search.mode = fast
 request.ui_dispatch_app = cyences_app_for_splunk
 request.ui_dispatch_view = search
-search = `cs_o365_managementactivity_change("Application")` _index_earliest=-31m@m _index_latest=-1m@m \
+search = `cs_o365_managementactivity_change("Application")` _index_earliest=-61m@m _index_latest=-1m@m \
 | `cs_o365_managementactivity_change_out` \
 | `cs_o365_application_change_internal_filter` \
 | `cs_o365_application_change_filter`  \
@@ -1672,7 +1672,7 @@ search = `cs_o365_managementactivity_change("Application")` _index_earliest=-31m
 action.summary_index = 1
 action.summary_index._name = cyences
 action.summary_index.category = O365
-action.summary_index.alert_name = O365 - Application Change/Update
+action.summary_index.alert_name = O365 - Azure Active Directory - Application Change/Update
 
 [O365 - Login Failure Due To Multi Factor Authentication]
 disabled = 1

--- a/cyences_app_for_splunk/default/savedsearches.conf
+++ b/cyences_app_for_splunk/default/savedsearches.conf
@@ -1560,7 +1560,7 @@ alert.suppress = 0
 counttype = number of events
 quantity = 0
 relation = greater than
-cron_schedule = 29 * * * *
+cron_schedule = 59 * * * *
 description = This alert will show the change/update in Group members. \
 \
 Data Collection - Office 365 management activity data (Splunk Add-on for Office 365). 
@@ -1591,7 +1591,7 @@ alert.suppress = 0
 counttype = number of events
 quantity = 0
 relation = greater than
-cron_schedule = 59 * * * *
+cron_schedule = 29 * * * *
 description = This alert will show the change/update in User. \
 \
 Data Collection - Office 365 management activity data (Splunk Add-on for Office 365). 


### PR DESCRIPTION
* Fix the alert_name field issue for forensic dasboard
* Fix management activity duplicate event issue
  *  https://docs.splunk.com/Documentation/AddOns/released/MSO365/Troubleshooting#Data_duplication_issues_when_fetching_multiple_content_URLs
* increase cron duration from every 30 minute to 60 minute for management activity related alerts