### PR TITLE
CY-381: Add Elapsed Time Per Session panel in the VPN dashboard

### DIFF
--- a/cyences_app_for_splunk/appserver/static/cs_configuration.js
+++ b/cyences_app_for_splunk/appserver/static/cs_configuration.js
@@ -23,6 +23,7 @@ require([
         { macro_name: 'cs_ad_active_directory', input_id: 'macro_data_ad_active_directory', button_id: 'macro_data_ad_active_directory_button', msg_id: 'macro_data_msg'},
         { macro_name: 'cs_ad_health_logs', input_id: 'macro_data_ad_health_logs', button_id: 'macro_data_ad_health_logs_button', msg_id: 'macro_data_msg'},
         { macro_name: 'cs_sysmon', input_id: 'macro_data_sysmon', button_id: 'macro_data_sysmon_button', msg_id: 'macro_data_msg'},
+        { macro_name: 'cs_fortigate', input_id: 'macro_data_fortigate', button_id: 'macro_data_fortigate_button', msg_id: 'macro_data_msg'},
         { macro_name: 'cs_palo', input_id: 'macro_data_palo', button_id: 'macro_data_palo_button', msg_id: 'macro_data_msg'},
         { macro_name: 'cs_vpn_indexes', input_id: 'macro_data_vpn', button_id: 'macro_data_vpn_button', msg_id: 'macro_data_msg'},
         { macro_name: 'cs_authentication_indexes', input_id: 'macro_data_authentication', button_id: 'macro_data_authentication_button', msg_id: 'macro_data_msg'},

--- a/cyences_app_for_splunk/default/data/ui/views/cs_configuration.xml
+++ b/cyences_app_for_splunk/default/data/ui/views/cs_configuration.xml
@@ -183,6 +183,15 @@
             </th>
           </tr>
           <tr>
+            <th style="text-align:left">FortiGate Data</th>
+            <th style="text-align:left">
+              <input type="text" id="macro_data_fortigate"/>
+            </th>
+            <th style="text-align:left">
+              <button id="macro_data_fortigate_button">Update</button>
+            </th>
+          </tr>
+          <tr>
             <th style="text-align:left">Palo Alto Data</th>
             <th style="text-align:left">
               <input type="text" id="macro_data_palo"/>

--- a/cyences_app_for_splunk/default/data/ui/views/cs_vpn_reports.xml
+++ b/cyences_app_for_splunk/default/data/ui/views/cs_vpn_reports.xml
@@ -238,4 +238,33 @@
       </table>
     </panel>
   </row>
+  <row>
+    <panel>
+      <title>Elapsed Time Per Session</title>
+      <table>
+        <search>
+          <query>`cs_vpn_indexes` eventtype="cs_*_vpn_logout" duration=* $User$ 
+| eval SourceIP=coalesce(public_ip, src), PrivateIP=if(coalesce(private_ip, tunnelip)="0.0.0.0", null(), coalesce(private_ip, tunnelip)) 
+| fillnull value="Unknown" SourceIP 
+| dedup _time user SourceIP 
+| iplocation SourceIP 
+| eval Country = if(isnull(Country) OR Country="", "Unknown", Country) 
+| eval City = if(isnull(City) OR City="", "Unknown", City) 
+| search $Country$ $City$ 
+| `cs_vpn_dashboard_filter` 
+| eval duration = tostring(duration, "duration") 
+| table _time user SourceIP PrivateIP duration City Country 
+| rename user as User, duration as Duration</query>
+          <earliest>$time.earliest$</earliest>
+          <latest>$time.latest$</latest>
+        </search>
+        <option name="count">5</option>
+        <option name="drilldown">row</option>
+        <option name="rowNumbers">true</option>
+        <drilldown>
+          <link target="_blank">search?q=%60cs_vpn_indexes%60%20TERM($row.User$)%20user%3D$row.User$%20TERM($row.SourceIP$)%20src%3D$row.SourceIP$&amp;earliest=$time.earliest$&amp;latest=$time.latest$</link>
+        </drilldown>
+      </table>
+    </panel>
+  </row>
 </form>

--- a/cyences_app_for_splunk/default/eventtypes.conf
+++ b/cyences_app_for_splunk/default/eventtypes.conf
@@ -2,21 +2,21 @@
 ### Global Protect ###
 ######################
 # Old
-[cs_palo_gp_old_login]
+[cs_palo_gp_old_vpn_login]
 search = (sourcetype=pan_system OR sourcetype=pan:system) (event_id="globalprotectportal-auth-*" OR event_id="globalprotectgateway-auth-*" OR event_id="globalprotectgateway-regist-*") log_subtype="globalprotect"
 
-[cs_palo_gp_old_logout]
+[cs_palo_gp_old_vpn_logout]
 search = (sourcetype=pan_system OR sourcetype=pan:system) (event_id="globalprotectgateway-logout-succ" OR event_id="globalprotectgateway-logout-fail") log_subtype="globalprotect"
 
 
 # New
-[cs_palo_gp_new_login]
+[cs_palo_gp_new_vpn_login]
 search = sourcetype="pan:globalprotect" (log_subtype="login" (event_id="portal-auth" OR event_id="gateway-auth")) OR (log_subtype="connected" event_id="gateway-connected")
 
-[cs_palo_gp_new_connected]
+[cs_palo_gp_new_vpn_connected]
 search = sourcetype="pan:globalprotect" log_subtype="connected" event_id="gateway-connected"
 
-[cs_palo_gp_new_logout]
+[cs_palo_gp_new_vpn_logout]
 search = sourcetype="pan:globalprotect" log_subtype="logout" event_id="gateway-logout"
 
 
@@ -30,7 +30,7 @@ search = sourcetype IN ("fgt_event", "fortigate_event") subtype="vpn" vendor_act
 search = sourcetype IN ("fgt_event", "fortigate_event") subtype="vpn" vendor_action IN ("tunnel-up", "phase2-up")
 
 [cs_fortigate_vpn_logout]
-search = sourcetype IN ("fgt_event", "fortigate_event") subtype="vpn" vendor_action IN ("ssl-web-close", "tunnel-down")
+search = sourcetype IN ("fgt_event", "fortigate_event") subtype="vpn" vendor_action IN ("tunnel-down")
 
 
 #################

--- a/cyences_app_for_splunk/default/macros.conf
+++ b/cyences_app_for_splunk/default/macros.conf
@@ -804,6 +804,12 @@ definition = search *
 iseval = 0
 
 
+# FortiGate
+[cs_fortigate]
+definition = index=fortigate
+iseval = 0
+
+
 # Sophos Central
 [cs_sophos]
 definition = index=sophos
@@ -942,8 +948,7 @@ iseval = 0
 
 # VPN
 [cs_vpn_indexes]
-definition = index=pan_log
-# Default value pan_log represents for Global protect VPN
+definition = (`cs_palo` OR `cs_fortigate`)
 iseval = 0
 
 [cs_vpn_dashboard_filter]

--- a/cyences_app_for_splunk/default/props.conf
+++ b/cyences_app_for_splunk/default/props.conf
@@ -168,9 +168,9 @@ FIELDALIAS-1vendor_user = user AS vendor_user
 EVAL-user = username
 EVAL-dest_category = if(rec_type_desc="New VPN Device Login", "vpn_auth", dest_category)
 EVAL-action = if(rec_type_desc="New VPN Device Login", "success", action)
-EVAL-src_ip = if(rec_type_desc="New VPN Device Login", client_ip, src_ip)
-EVAL-src = if(rec_type_desc="New VPN Device Login", client_ip, src)
-
+EVAL-src_ip = if(rec_type_desc="New VPN Device Login" OR rec_type_desc="New VPN Device Logoff", client_ip, src_ip)
+EVAL-src = if(rec_type_desc="New VPN Device Login" OR rec_type_desc="New VPN Device Logoff", client_ip, src)
+EVAL-private_ip = if(rec_type_desc="New VPN Device Login" OR rec_type_desc="New VPN Device Logoff", src_host, private_ip)
 
 
 

--- a/cyences_app_for_splunk/default/tags.conf
+++ b/cyences_app_for_splunk/default/tags.conf
@@ -4,32 +4,32 @@
 # DMs
 # CIM - Authentication
 # CIM - NetworkSessions
-[eventtype=cs_palo_gp_old_login]
+[eventtype=cs_palo_gp_old_vpn_login]
 authentication = enabled
 vpn = enabled
 network = enabled
 session = enabled
 start = enabled
 
-[eventtype=cs_palo_gp_new_login]
+[eventtype=cs_palo_gp_new_vpn_login]
 authentication = enabled
 vpn = enabled
 network = enabled
 session = enabled
 start = enabled
 
-[eventtype=cs_palo_gp_new_connected]
+[eventtype=cs_palo_gp_new_vpn_connected]
 vpn = enabled
 network = enabled
 session = enabled
 
-[eventtype=cs_palo_gp_new_logout]
+[eventtype=cs_palo_gp_new_vpn_logout]
 vpn = enabled
 network = enabled
 session = enabled
 end = enabled
 
-[eventtype=cs_palo_gp_old_logout]
+[eventtype=cs_palo_gp_old_vpn_logout]
 vpn = enabled
 network = enabled
 session = enabled


### PR DESCRIPTION
* Add Elapsed Time Per Session panel in the VPN dashboard
* Add fortigate macro
* Rename palo vpn eventypes for consistence naming across vpn eventtypes
* Update src_ip and private_ip field extraction for Cisco VPN logoff event